### PR TITLE
Prefer ctx.RoutePattern() over ctx.RoutePatterns[]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tjefferson08/otelchi
+module github.com/riandyrn/otelchi
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/riandyrn/otelchi
+module github.com/tjefferson08/otelchi
 
 go 1.15
 

--- a/middleware.go
+++ b/middleware.go
@@ -113,7 +113,7 @@ func (tw traceware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// in go-chi/chi, full route pattern could only be extracted once the request is executed
 	// check here for details: https://github.com/go-chi/chi/issues/150#issuecomment-278850733
-	routeStr := strings.Join(chi.RouteContext(r2.Context()).RoutePatterns, "")
+	routeStr := chi.RouteContext(r2.Context()).RoutePattern()
 	attrs := semconv.HTTPAttributesFromHTTPStatusCode(rrw.status)
 	attrs = append(attrs, semconv.NetAttributesFromHTTPRequest("tcp", r2)...)
 	attrs = append(attrs, semconv.EndUserAttributesFromHTTPRequest(r2)...)

--- a/middleware.go
+++ b/middleware.go
@@ -2,7 +2,6 @@ package otelchi
 
 import (
 	"net/http"
-	"strings"
 	"sync"
 
 	"github.com/felixge/httpsnoop"


### PR DESCRIPTION
Since it strips out noisy wildcards