### PR TITLE
[Add Example Build to CI]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,3 +23,5 @@ jobs:
         run: go test ./...
       - name: Build
         run: go build
+      - name: Build Example
+        run: go build -o example-build ./example


### PR DESCRIPTION
This is to make sure to example could still be build.