### PR TITLE
feat: add HTTP method to span name

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -2,6 +2,7 @@ package otelchi
 
 import (
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/felixge/httpsnoop"
@@ -118,7 +119,7 @@ func (tw traceware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	attrs = append(attrs, semconv.EndUserAttributesFromHTTPRequest(r2)...)
 	attrs = append(attrs, semconv.HTTPServerAttributesFromHTTPRequest(tw.serverName, routeStr, r2)...)
 	span.SetAttributes(attrs...)
-	span.SetName(routeStr)
+	span.SetName(strings.ToUpper(r.Method) + " " + routeStr)
 
 	spanStatus, spanMessage := semconv.SpanStatusFromHTTPStatusCode(rrw.status)
 	span.SetStatus(spanStatus, spanMessage)

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -167,14 +167,14 @@ func TestSDKIntegration(t *testing.T) {
 	router.HandleFunc("/book/{title}", ok)
 
 	r0 := httptest.NewRequest("GET", "/user/123", nil)
-	r1 := httptest.NewRequest("GET", "/book/foo", nil)
+	r1 := httptest.NewRequest("POST", "/book/foo", nil)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r0)
 	router.ServeHTTP(w, r1)
 
 	require.Len(t, sr.Ended(), 2)
 	assertSpan(t, sr.Ended()[0],
-		"/user/{id:[0-9]+}",
+		"GET /user/{id:[0-9]+}",
 		trace.SpanKindServer,
 		attribute.String("http.server_name", "foobar"),
 		attribute.Int("http.status_code", http.StatusOK),
@@ -183,11 +183,11 @@ func TestSDKIntegration(t *testing.T) {
 		attribute.String("http.route", "/user/{id:[0-9]+}"),
 	)
 	assertSpan(t, sr.Ended()[1],
-		"/book/{title}",
+		"POST /book/{title}",
 		trace.SpanKindServer,
 		attribute.String("http.server_name", "foobar"),
 		attribute.Int("http.status_code", http.StatusOK),
-		attribute.String("http.method", "GET"),
+		attribute.String("http.method", "POST"),
 		attribute.String("http.target", "/book/foo"),
 		attribute.String("http.route", "/book/{title}"),
 	)


### PR DESCRIPTION
GET /thing/{id}
POST /thing/{id}

is perhaps a bit clearer as a top level name than just

/thing/{id}