### PR TITLE
[Add Option `WithRequestMethodInSpanName()`]

### DIFF
--- a/config.go
+++ b/config.go
@@ -43,7 +43,11 @@ func WithTracerProvider(provider oteltrace.TracerProvider) Option {
 }
 
 // WithChiRoutes specified the routes that being used by application. Its main
-// purpose is to provide route pattern on span creation.
+// purpose is to provide route pattern as span name during span creation. If this
+// option is not set, by default the span will be given name at the end of span
+// execution. For some people, this behavior is not desirable since they want
+// to override the span name on underlying handler. By setting this option, it
+// is possible for them to override the span name.
 func WithChiRoutes(routes chi.Routes) Option {
 	return optionFunc(func(cfg *config) {
 		cfg.ChiRoutes = routes

--- a/config.go
+++ b/config.go
@@ -8,9 +8,10 @@ import (
 
 // config is used to configure the mux middleware.
 type config struct {
-	TracerProvider oteltrace.TracerProvider
-	Propagators    propagation.TextMapPropagator
-	ChiRoutes      chi.Routes
+	TracerProvider          oteltrace.TracerProvider
+	Propagators             propagation.TextMapPropagator
+	ChiRoutes               chi.Routes
+	RequestMethodInSpanName bool
 }
 
 // Option specifies instrumentation configuration options.
@@ -46,5 +47,20 @@ func WithTracerProvider(provider oteltrace.TracerProvider) Option {
 func WithChiRoutes(routes chi.Routes) Option {
 	return optionFunc(func(cfg *config) {
 		cfg.ChiRoutes = routes
+	})
+}
+
+// WithRequestMethodInSpanName is used for adding http request method to span name.
+// While this is not necessary for vendors that properly implemented the tracing
+// specs (e.g Jaeger, AWS X-Ray, etc...), but for other vendors such as Elastic
+// and New Relic this might be helpful.
+//
+// See following threads for details:
+//
+// - https://github.com/riandyrn/otelchi/pull/3#issuecomment-1005883910
+// - https://github.com/riandyrn/otelchi/issues/6#issuecomment-1034461912
+func WithRequestMethodInSpanName(isActive bool) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.RequestMethodInSpanName = isActive
 	})
 }

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -236,6 +236,53 @@ func TestSDKIntegrationWithChiRoutes(t *testing.T) {
 	)
 }
 
+func TestSDKIntegrationOverrideSpanName(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider()
+	provider.RegisterSpanProcessor(sr)
+
+	router := chi.NewRouter()
+	router.Use(
+		Middleware(
+			"foobar",
+			WithTracerProvider(provider),
+			WithChiRoutes(router),
+		),
+	)
+	router.HandleFunc("/user/{id:[0-9]+}", func(w http.ResponseWriter, r *http.Request) {
+		span := trace.SpanFromContext(r.Context())
+		span.SetName("overriden span name")
+		w.WriteHeader(http.StatusOK)
+	})
+	router.HandleFunc("/book/{title}", ok)
+
+	r0 := httptest.NewRequest("GET", "/user/123", nil)
+	r1 := httptest.NewRequest("GET", "/book/foo", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r0)
+	router.ServeHTTP(w, r1)
+
+	require.Len(t, sr.Ended(), 2)
+	assertSpan(t, sr.Ended()[0],
+		"overriden span name",
+		trace.SpanKindServer,
+		attribute.String("http.server_name", "foobar"),
+		attribute.Int("http.status_code", http.StatusOK),
+		attribute.String("http.method", "GET"),
+		attribute.String("http.target", "/user/123"),
+		attribute.String("http.route", "/user/{id:[0-9]+}"),
+	)
+	assertSpan(t, sr.Ended()[1],
+		"/book/{title}",
+		trace.SpanKindServer,
+		attribute.String("http.server_name", "foobar"),
+		attribute.Int("http.status_code", http.StatusOK),
+		attribute.String("http.method", "GET"),
+		attribute.String("http.target", "/book/foo"),
+		attribute.String("http.route", "/book/{title}"),
+	)
+}
+
 func TestSDKIntegrationWithRequestMethodInSpanName(t *testing.T) {
 	sr := tracetest.NewSpanRecorder()
 	provider := sdktrace.NewTracerProvider()


### PR DESCRIPTION
There are tracing collector from some vendors that do not include HTTP request method in their span propagation.

This create confusion when all http request methods apply to the same route. So this PR tried to solve this issue.

See following threads for details:

- https://github.com/riandyrn/otelchi/pull/3#issuecomment-1005883910
- https://github.com/riandyrn/otelchi/issues/6#issuecomment-1034461912