### PR TITLE
add metrics & update dependencies

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+	otelmetric "go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
@@ -17,6 +18,7 @@ const (
 // config is used to configure the mux middleware.
 type config struct {
 	TracerProvider                oteltrace.TracerProvider
+	MeterProvider                 otelmetric.MeterProvider
 	Propagators                   propagation.TextMapPropagator
 	ChiRoutes                     chi.Routes
 	RequestMethodInSpanName       bool
@@ -24,6 +26,9 @@ type config struct {
 	TraceIDResponseHeaderKey      string
 	TraceSampledResponseHeaderKey string
 	PublicEndpointFn              func(r *http.Request) bool
+
+	DisableMeasureInflight bool
+	DisableMeasureSize     bool
 }
 
 // Option specifies instrumentation configuration options.
@@ -55,6 +60,30 @@ func WithPropagators(propagators propagation.TextMapPropagator) Option {
 func WithTracerProvider(provider oteltrace.TracerProvider) Option {
 	return optionFunc(func(cfg *config) {
 		cfg.TracerProvider = provider
+	})
+}
+
+// WithMeterProvider specifies a meter provider to use for creating a meter.
+// If none is specified, the global provider is used.
+func WithMeterProvider(provider otelmetric.MeterProvider) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.MeterProvider = provider
+	})
+}
+
+// WithMeasureInflightDisabled specifies whether to measure the number of inflight requests.
+// If this option is not set, the number of inflight requests will be measured.
+func WithMeasureInflightDisabled(isDisabled bool) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.DisableMeasureInflight = isDisabled
+	})
+}
+
+// WithMeasureSizeDisabled specifies whether to measure the size of the response body.
+// If this option is not set, the size of the response body will be measured.
+func WithMeasureSizeDisabled(isDisabled bool) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.DisableMeasureSize = isDisabled
 	})
 }
 

--- a/examples/basic/go.mod
+++ b/examples/basic/go.mod
@@ -8,8 +8,10 @@ require (
 	github.com/go-chi/chi/v5 v5.1.0
 	github.com/riandyrn/otelchi v0.10.0
 	go.opentelemetry.io/otel v1.30.0
+	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.30.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.30.0
 	go.opentelemetry.io/otel/sdk v1.30.0
+	go.opentelemetry.io/otel/sdk/metric v1.30.0
 	go.opentelemetry.io/otel/trace v1.30.0
 )
 

--- a/examples/basic/go.sum
+++ b/examples/basic/go.sum
@@ -19,12 +19,16 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.opentelemetry.io/otel v1.30.0 h1:F2t8sK4qf1fAmY9ua4ohFS/K+FUuOPemHUIXHtktrts=
 go.opentelemetry.io/otel v1.30.0/go.mod h1:tFw4Br9b7fOS+uEao81PJjVMjW/5fvNCbpsDIXqP0pc=
+go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.30.0 h1:IyFlqNsi8VT/nwYlLJfdM0y1gavxGpEvnf6FtVfZ6X4=
+go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.30.0/go.mod h1:bxiX8eUeKoAEQmbq/ecUT8UqZwCjZW52yJrXJUSozsk=
 go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.30.0 h1:kn1BudCgwtE7PxLqcZkErpD8GKqLZ6BSzeW9QihQJeM=
 go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.30.0/go.mod h1:ljkUDtAMdleoi9tIG1R6dJUpVwDcYjw3J2Q6Q/SuiC0=
 go.opentelemetry.io/otel/metric v1.30.0 h1:4xNulvn9gjzo4hjg+wzIKG7iNFEaBMX00Qd4QIZs7+w=
 go.opentelemetry.io/otel/metric v1.30.0/go.mod h1:aXTfST94tswhWEb+5QjlSqG+cZlmyXy/u8jFpor3WqQ=
 go.opentelemetry.io/otel/sdk v1.30.0 h1:cHdik6irO49R5IysVhdn8oaiR9m8XluDaJAs4DfOrYE=
 go.opentelemetry.io/otel/sdk v1.30.0/go.mod h1:p14X4Ok8S+sygzblytT1nqG98QG2KYKv++HE0LY/mhg=
+go.opentelemetry.io/otel/sdk/metric v1.30.0 h1:QJLT8Pe11jyHBHfSAgYH7kEmT24eX792jZO1bo4BXkM=
+go.opentelemetry.io/otel/sdk/metric v1.30.0/go.mod h1:waS6P3YqFNzeP01kuo/MBBYqaoBJl7efRQHOaydhy1Y=
 go.opentelemetry.io/otel/trace v1.30.0 h1:7UBkkYzeg3C7kQX8VAidWh2biiQbtAKjyIML8dQ9wmc=
 go.opentelemetry.io/otel/trace v1.30.0/go.mod h1:5EyKqTzzmyqB9bwtCCq6pDLktPK6fmGf/Dph+8VI02o=
 golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -5,32 +5,39 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/riandyrn/otelchi"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/stdout/stdoutmetric"
+	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/propagation"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
-
-	stdout "go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/riandyrn/otelchi"
 )
 
 var tracer oteltrace.Tracer
 
 func main() {
 	// initialize trace provider
-	tp := initTracerProvider()
+	tp, mp := initOtelProviders()
 	defer func() {
 		if err := tp.Shutdown(context.Background()); err != nil {
 			log.Printf("Error shutting down tracer provider: %v", err)
 		}
+		if err := mp.Shutdown(context.Background()); err != nil {
+			log.Printf("Error shutting down meter provider: %v", err)
+		}
 	}()
 	// set global tracer provider & text propagators
 	otel.SetTracerProvider(tp)
+	otel.SetMeterProvider(mp)
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
 	// initialize tracer
 	tracer = otel.Tracer("mux-server")
@@ -38,22 +45,28 @@ func main() {
 	// define router
 	r := chi.NewRouter()
 	r.Use(otelchi.Middleware("my-server", otelchi.WithChiRoutes(r)))
-	r.HandleFunc("/users/{id:[0-9]+}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.HandleFunc("/users/{id:[0-9]+}", func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
 		name := getUser(r.Context(), id)
 		reply := fmt.Sprintf("user %s (id %s)\n", name, id)
 		w.Write(([]byte)(reply))
-	}))
+	})
 
 	// serve router
 	_ = http.ListenAndServe(":8080", r)
 }
 
-func initTracerProvider() *sdktrace.TracerProvider {
-	exporter, err := stdout.New(stdout.WithPrettyPrint())
+func initOtelProviders() (*sdktrace.TracerProvider, *sdkmetric.MeterProvider) {
+	traceExporter, err := stdouttrace.New(stdouttrace.WithPrettyPrint())
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	metricExporter, err := stdoutmetric.New(stdoutmetric.WithPrettyPrint())
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	res, err := resource.New(
 		context.Background(),
 		resource.WithAttributes(
@@ -65,10 +78,15 @@ func initTracerProvider() *sdktrace.TracerProvider {
 		log.Fatalf("unable to initialize resource due: %v", err)
 	}
 	return sdktrace.NewTracerProvider(
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
-		sdktrace.WithBatcher(exporter),
-		sdktrace.WithResource(res),
-	)
+			sdktrace.WithSampler(sdktrace.AlwaysSample()),
+			sdktrace.WithBatcher(traceExporter),
+			sdktrace.WithResource(res),
+		), sdkmetric.NewMeterProvider(
+			sdkmetric.WithReader(sdkmetric.NewPeriodicReader(metricExporter,
+				sdkmetric.WithInterval(time.Second*30),
+			)),
+			sdkmetric.WithResource(res),
+		)
 }
 
 func getUser(ctx context.Context, id string) string {

--- a/examples/multi-services/back-svc/main.go
+++ b/examples/multi-services/back-svc/main.go
@@ -9,9 +9,10 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/riandyrn/otelchi"
 	"github.com/riandyrn/otelchi/examples/multi-services/utils"
-	"go.opentelemetry.io/otel/trace"
 )
 
 const (
@@ -25,6 +26,11 @@ func main() {
 	if err != nil {
 		log.Fatalf("unable to initialize tracer provider due: %v", err)
 	}
+
+	if err = utils.NewMeter(serviceName); err != nil {
+		log.Fatalf("unable to initialize meter provider due: %v", err)
+	}
+
 	// define router
 	r := chi.NewRouter()
 	r.Use(otelchi.Middleware(serviceName, otelchi.WithChiRoutes(r)))

--- a/examples/multi-services/front-svc/main.go
+++ b/examples/multi-services/front-svc/main.go
@@ -3,17 +3,18 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/riandyrn/otelchi"
-	"github.com/riandyrn/otelchi/examples/multi-services/utils"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/riandyrn/otelchi"
+	"github.com/riandyrn/otelchi/examples/multi-services/utils"
 )
 
 const (
@@ -28,6 +29,11 @@ func main() {
 	if err != nil {
 		log.Fatalf("unable to initialize tracer due: %v", err)
 	}
+
+	if err = utils.NewMeter(serviceName); err != nil {
+		log.Fatalf("unable to initialize meter provider due: %v", err)
+	}
+
 	// define router
 	r := chi.NewRouter()
 	r.Use(otelchi.Middleware(serviceName, otelchi.WithChiRoutes(r)))
@@ -66,7 +72,7 @@ func getRandomName(ctx context.Context, tracer trace.Tracer) (string, error) {
 	defer resp.Body.Close()
 
 	// read response body
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		err = fmt.Errorf("unable to read response data due: %w", err)
 		span.RecordError(err)

--- a/examples/multi-services/go.mod
+++ b/examples/multi-services/go.mod
@@ -9,9 +9,11 @@ require (
 	github.com/riandyrn/otelchi v0.10.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0
 	go.opentelemetry.io/otel v1.30.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.30.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.30.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.30.0
 	go.opentelemetry.io/otel/sdk v1.30.0
+	go.opentelemetry.io/otel/sdk/metric v1.30.0
 	go.opentelemetry.io/otel/trace v1.30.0
 )
 

--- a/examples/multi-services/go.sum
+++ b/examples/multi-services/go.sum
@@ -25,6 +25,8 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0 h1:4K4tsIX
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0/go.mod h1:jjdQuTGVsXV4vSs+CJ2qYDeDPf9yIJV23qlIzBm73Vg=
 go.opentelemetry.io/otel v1.30.0 h1:F2t8sK4qf1fAmY9ua4ohFS/K+FUuOPemHUIXHtktrts=
 go.opentelemetry.io/otel v1.30.0/go.mod h1:tFw4Br9b7fOS+uEao81PJjVMjW/5fvNCbpsDIXqP0pc=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.30.0 h1:VrMAbeJz4gnVDg2zEzjHG4dEH86j4jO6VYB+NgtGD8s=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.30.0/go.mod h1:qqN/uFdpeitTvm+JDqqnjm517pmQRYxTORbETHq5tOc=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.30.0 h1:lsInsfvhVIfOI6qHVyysXMNDnjO9Npvl7tlDPJFBVd4=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.30.0/go.mod h1:KQsVNh4OjgjTG0G6EiNi1jVpnaeeKsKMRwbLN+f1+8M=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.30.0 h1:umZgi92IyxfXd/l4kaDhnKgY8rnN/cZcF1LKc6I8OQ8=
@@ -33,6 +35,8 @@ go.opentelemetry.io/otel/metric v1.30.0 h1:4xNulvn9gjzo4hjg+wzIKG7iNFEaBMX00Qd4Q
 go.opentelemetry.io/otel/metric v1.30.0/go.mod h1:aXTfST94tswhWEb+5QjlSqG+cZlmyXy/u8jFpor3WqQ=
 go.opentelemetry.io/otel/sdk v1.30.0 h1:cHdik6irO49R5IysVhdn8oaiR9m8XluDaJAs4DfOrYE=
 go.opentelemetry.io/otel/sdk v1.30.0/go.mod h1:p14X4Ok8S+sygzblytT1nqG98QG2KYKv++HE0LY/mhg=
+go.opentelemetry.io/otel/sdk/metric v1.30.0 h1:QJLT8Pe11jyHBHfSAgYH7kEmT24eX792jZO1bo4BXkM=
+go.opentelemetry.io/otel/sdk/metric v1.30.0/go.mod h1:waS6P3YqFNzeP01kuo/MBBYqaoBJl7efRQHOaydhy1Y=
 go.opentelemetry.io/otel/trace v1.30.0 h1:7UBkkYzeg3C7kQX8VAidWh2biiQbtAKjyIML8dQ9wmc=
 go.opentelemetry.io/otel/trace v1.30.0/go.mod h1:5EyKqTzzmyqB9bwtCCq6pDLktPK6fmGf/Dph+8VI02o=
 go.opentelemetry.io/proto/otlp v1.3.1 h1:TrMUixzpM0yuc/znrFTP9MMRh8trP93mkCiDVeXrui0=

--- a/examples/multi-services/utils/meter.go
+++ b/examples/multi-services/utils/meter.go
@@ -1,0 +1,39 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+)
+
+func NewMeter(svcName string) error {
+	// create otlp exporter, notice that here we are using insecure option
+	// because we just want to export the trace locally, also notice that
+	// here we don't set any endpoint because by default the otel will load
+	// the endpoint from the environment variable `OTEL_EXPORTER_OTLP_ENDPOINT`
+	exporter, err := otlpmetrichttp.New(
+		context.Background(),
+	)
+	if err != nil {
+		return fmt.Errorf("unable to initialize exporter due: %w", err)
+	}
+	// initialize tracer provider
+	tp := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter, sdkmetric.WithInterval(30*time.Second))),
+		sdkmetric.WithResource(resource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceNameKey.String(svcName),
+		)),
+	)
+	// set tracer provider and propagator properly, this is to ensure all
+	// instrumentation library could run well
+	otel.SetMeterProvider(tp)
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-chi/chi/v5 v5.1.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/otel v1.30.0
+	go.opentelemetry.io/otel/metric v1.30.0
 	go.opentelemetry.io/otel/sdk v1.30.0
 	go.opentelemetry.io/otel/trace v1.30.0
 )
@@ -17,7 +18,6 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.30.0 // indirect
 	golang.org/x/sys v0.25.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,88 @@
+package otelchi
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
+)
+
+var (
+	serviceKey = attribute.Key("service")
+	idKey      = attribute.Key("id")
+	methodKey  = attribute.Key("method")
+	codeKey    = attribute.Key("code")
+)
+
+type httpReqProperties struct {
+	Service string
+	ID      string
+	Method  string
+	Code    int
+}
+
+func newMetricsRecorder(meter otelmetric.Meter) *metricsRecorder {
+	httpRequestDurHistogram, err := meter.Int64Histogram("request_duration_seconds")
+	if err != nil {
+		panic(fmt.Sprintf("failed to create request_duration_seconds histogram: %v", err))
+	}
+
+	httpResponseSizeHistogram, err := meter.Int64Histogram("response_size_bytes")
+	if err != nil {
+		panic(fmt.Sprintf("failed to create response_size_bytes histogram: %v", err))
+	}
+
+	httpRequestsInflight, err := meter.Int64UpDownCounter("requests_inflight")
+	if err != nil {
+		panic(fmt.Sprintf("failed to create requests_inflight counter: %v", err))
+	}
+
+	return &metricsRecorder{
+		httpRequestDurHistogram:   httpRequestDurHistogram,
+		httpResponseSizeHistogram: httpResponseSizeHistogram,
+		httpRequestsInflight:      httpRequestsInflight,
+	}
+}
+
+type metricsRecorder struct {
+	httpRequestDurHistogram   otelmetric.Int64Histogram
+	httpResponseSizeHistogram otelmetric.Int64Histogram
+	httpRequestsInflight      otelmetric.Int64UpDownCounter
+}
+
+func (r *metricsRecorder) RecordRequestDuration(ctx context.Context, p httpReqProperties, duration time.Duration) {
+	r.httpRequestDurHistogram.Record(ctx,
+		int64(duration.Seconds()),
+		otelmetric.WithAttributes(
+			serviceKey.String(p.Service),
+			idKey.String(p.ID),
+			methodKey.String(p.Method),
+			codeKey.Int(p.Code),
+		),
+	)
+}
+
+func (r *metricsRecorder) RecordResponseSize(ctx context.Context, p httpReqProperties, size int64) {
+	r.httpResponseSizeHistogram.Record(ctx,
+		size,
+		otelmetric.WithAttributes(
+			serviceKey.String(p.Service),
+			idKey.String(p.ID),
+			methodKey.String(p.Method),
+			codeKey.Int(p.Code),
+		),
+	)
+}
+
+func (r *metricsRecorder) RecordRequestsInflight(ctx context.Context, p httpReqProperties, count int64) {
+	r.httpRequestsInflight.Add(ctx,
+		count,
+		otelmetric.WithAttributes(
+			serviceKey.String(p.Service),
+			idKey.String(p.ID),
+			methodKey.String(p.Method),
+		),
+	)
+}


### PR DESCRIPTION
it's been a while since I implemented this but I have been using since earlier this year and figured I'd pr it before it's too late

this adds support for basic metrics:
histogram: `request_duration_seconds`
histogram: `response_size_bytes`
up/down counter: `requests_inflight`

I'm happy to address any issues