### PR TITLE
Docs: Add Repo Essential Docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,122 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Add `WithTraceResponseHeaderKey` option to set custom response header key. (#23)
+- Add multiple go versions test scripts for local and CI pipeline. (#29)
+- Add compatibility testing for `ubuntu`, `macos` and `windows`. (#32)
+- Add repo essentials docs. (#33)
+
+### Changed
+
+- Upgrade to `v5.0.12` of `go-chi/chi`. (#29)
+- Upgrade to `v1.10.0` of `go.opentelemetry.io/otel`. (#29)
+- Upgrade to `v1.12.0` of `go.opentelemetry.io/otel/semconv`. (#29)
+
+## [0.5.2] - 2024-03-25
+
+### Fixed
+
+- Fix empty status code. (#30)
+
+### Changed
+
+- Return `http.StatusOK` (200) as a default `http.status_code` span attribute. (#30)
+
+## [0.5.1] - 2023-02-18
+
+### Fixed
+
+- Fix broken empty routes. (#18)
+
+### Changed
+
+- Upgrade to `v5.0.8` of `go-chi/chi`.
+
+## [0.5.0] - 2022-10-02
+
+### Added
+
+- Add multi services example. (#9)
+- Add `WithFilter()` option to ignore tracing in certain endpoints. (#11)
+
+## [0.4.0] - 2022-02-22
+
+### Added
+
+- Add Option `WithRequestMethodInSpanName()` to handle vendor that do not include HTTP request method as mentioned in #6. (#7)
+- Refine description for `WithChiRoutes()` option to announce it is possible to override the span name in underlying handler with this option.
+
+### Changed
+
+## [0.3.0] - 2022-01-18
+
+### Fixed
+
+- Fix both `docker-compose.yml` & `Dockerfile` in the example. (#5)
+
+### Added
+
+- Add `WithChiRoutes()` option to make the middleware able to determine full route pattern on span creation. (#5)
+- Set all known span attributes on span creation rather than set them after request is being executed. (#5)
+
+## [0.2.1] - 2022-01-08
+
+### Added
+
+- Add build example to CI pipeline. (#2)
+
+### Changed
+
+- Use `ctx.RoutePattern()` to get span name, this is to strip out noisy wildcard pattern. (#1)
+
+## [0.2.0] - 2021-10-18
+
+### Added
+
+- Set service name on tracer provider from code example.
+
+### Changed
+
+- Update dependencies in go.mod
+- Upgrade to `v1.0.1` of `go.opentelemetry.io/otel`.
+- Upgrade to `v5.0.4` of `go-chi/chi`.
+- Update latest test to use `otelmux` format.
+
+### Removed
+
+- Remove `HTTPResponseContentLengthKey`
+- Remove `HTTPTargetKey`, since automatically set in `HTTPServerAttributesFromHTTPRequest`
+
+## [0.1.0] - 2021-08-11
+
+This is the first release of otelchi.
+It contains instrumentation for trace and depends on:
+
+- otel => `v1.0.0-RC2`
+- go-chi/chi => `v5.0.3`
+
+### Added
+
+- Instrumentation for trace.
+- CI files.
+- Example code for a basic usage.
+- Apache-2.0 license.
+
+[Unreleased]: https://github.com/riandyrn/otelchi/compare/v0.5.2...HEAD
+[0.5.2]: https://github.com/riandyrn/otelchi/releases/tag/v0.5.2
+[0.5.1]: https://github.com/riandyrn/otelchi/releases/tag/v0.5.1
+[0.5.0]: https://github.com/riandyrn/otelchi/releases/tag/v0.5.0
+[0.4.0]: https://github.com/riandyrn/otelchi/releases/tag/v0.4.0
+[0.3.0]: https://github.com/riandyrn/otelchi/releases/tag/v0.3.0
+[0.2.1]: https://github.com/riandyrn/otelchi/releases/tag/v0.2.1
+[0.2.0]: https://github.com/riandyrn/otelchi/releases/tag/v0.2.0
+[0.1.0]: https://github.com/riandyrn/otelchi/releases/tag/v0.1.0

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,1 @@
-* @riandyrn
-* @ilhamsyahids
-* @mustafasegf
-* @ProtozoaJr
+* @riandyrn @ilhamsyahids @mustafasegf @ProtozoaJr

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+* @riandyrn
+* @ilhamsyahids
+* @mustafasegf
+* @ProtozoaJr

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,11 +13,11 @@ This procedure is used when we want to create new release from the latest develo
 
 The steps for this procedure are the following:
 
-1. Create new branch from the `master` branch with the following name format: `pre_release/v{MAJOR}.{MINOR}.{BUILD}`. For example, if we want to release for version `0.6.0`, we will first create a new branch from the `master` called `pre_release/v0.6.0`.
+1. Create a new branch from the `master` branch with the following name format: `pre_release/v{MAJOR}.{MINOR}.{BUILD}`. For example, if we want to release for version `0.6.0`, we will first create a new branch from the `master` called `pre_release/v0.6.0`.
 2. Update method `Version()` in `version.go` to return the target version.
 3. Update the `CHANGELOG.md` to include all the notable changes.
 4. Create a new PR from this branch to `master` with the title: `Release v{MAJOR}.{MINOR}.{BUILD}` (e.g `Release v0.6.0`).
-5. One maintainers should at least approve the PR.
+5. At least one maintainer should approve the PR.
 6. Upon approval, the PR will be merged to `master` and the branch will be deleted.
 7. Create new release from the `master` branch.
 8. Set the title to `Release v{MAJOR}.{MINOR}.{BUILD}` (e.g `Release v0.6.0`).
@@ -29,4 +29,20 @@ The steps for this procedure are the following:
 
 ## Non-Latest Release
 
-<!-- This procedure is used when we need to create fix or patch to the older releases. For example our latest release is ` -->
+This procedure is used when we need to create fix or patch for the older releases. Consider the following scenario:
+
+1. For example our latest release is version `0.7.1` which has the minimum go version `1.18`.
+2. Let say our user got a critical bug in version `0.6.0` which has the minimum go version `1.15`.
+3. Due to some constraints, this user cannot upgrade his/her minimum go version.
+4. We decided to create fix for this version by releasing `0.6.1`.
+
+In this scenario, the procedure is the following:
+
+1. Create a new branch from the version that we want to patch. 
+2. We name the new branch with the increment in the build value. So for example if we want to create patch for `0.6.0`, then we should create new branch with name: `patch_release/v0.6.1`.
+3. We create again new branch that will use `patch_release/v0.6.1` as base. Let say `fix/handle-cve-233`.
+4. We will push any necessary changes to `fix/handle-cve-233`.
+5. Create a new PR that target `patch_release/v0.6.1`.
+6. Follow step `2-10` as described in the [Latest Release](#latest-release).
+7. Publish the release without setting the release as the latest release.
+8. Done.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -21,10 +21,11 @@ The steps for this procedure are the following:
 6. Upon approval, the PR will be merged to `master` and the branch will be deleted.
 7. Create new release from the `master` branch.
 8. Set the title to `Release v{MAJOR}.{MINOR}.{BUILD}` (e.g `Release v0.6.0`).
-9. Set the newly release tag using this format `v{MAJOR}.{MINOR}.{BUILD}` (e.g `v0.6.0`).
+9. Set the newly release tag using this format: `v{MAJOR}.{MINOR}.{BUILD}` (e.g `v0.6.0`).
 10. Set the description of the release to match with the content inside `CHANGELOG.md`.
 11. Set the release as the latest release.
-12. Done.
+12. Publish the release.
+13. Done.
 
 ## Non-Latest Release
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,26 @@
+# Release Process
+
+This document explains how to create releases in this project in each release scenario.
+
+Currently there are 2 release procedures for this project:
+
+- [Latest Release](#latest-release)
+- [Non-Latest Release](#non-latest-release)
+
+## Latest Release
+
+This procedure is used when we want to create new release from the latest development edge (latest commit in the `master` branch).
+
+The steps for this procedure are the following:
+
+1. Create new branch from the `master` branch with the following name format: `pre_release/v{MAJOR}.{MINOR}.{BUILD}`. For example, if we want to release for version `0.6.0`, we will first create a new branch from the `master` called `pre_release/v0.6.0`.
+2. Update method `Version()` in `version.go` to return the target version.
+3. Update the `CHANGELOG.md` to include all the notable changes.
+4. Create a new PR from this branch to `master` with the title: `Release v{MAJOR}.{MINOR}.{BUILD}` (e.g `Release v0.6.0`).
+5. One maintainers should at least approve the PR.
+6. Upon approval, the PR will be merged to `master`.
+7. Create new release with the description & tag matches the content inside `CHANGELOG.md`. Set the title to `Release v{MAJOR}.{MINOR}.{BUILD}` (e.g `Release v0.6.0`).
+8. Set the release as the latest release.
+9. Done.
+
+## Non-Latest Release

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,9 +18,14 @@ The steps for this procedure are the following:
 3. Update the `CHANGELOG.md` to include all the notable changes.
 4. Create a new PR from this branch to `master` with the title: `Release v{MAJOR}.{MINOR}.{BUILD}` (e.g `Release v0.6.0`).
 5. One maintainers should at least approve the PR.
-6. Upon approval, the PR will be merged to `master`.
-7. Create new release with the description & tag matches the content inside `CHANGELOG.md`. Set the title to `Release v{MAJOR}.{MINOR}.{BUILD}` (e.g `Release v0.6.0`).
-8. Set the release as the latest release.
-9. Done.
+6. Upon approval, the PR will be merged to `master` and the branch will be deleted.
+7. Create new release from the `master` branch.
+8. Set the title to `Release v{MAJOR}.{MINOR}.{BUILD}` (e.g `Release v0.6.0`).
+9. Set the newly release tag using this format `v{MAJOR}.{MINOR}.{BUILD}` (e.g `v0.6.0`).
+10. Set the description of the release to match with the content inside `CHANGELOG.md`.
+11. Set the release as the latest release.
+12. Done.
 
 ## Non-Latest Release
+
+<!-- This procedure is used when we need to create fix or patch to the older releases. For example our latest release is ` -->

--- a/middleware.go
+++ b/middleware.go
@@ -15,8 +15,7 @@ import (
 )
 
 const (
-	tracerName             = "github.com/riandyrn/otelchi"
-	instrumentationVersion = "0.6.0" // TODO: we need to find a way to automate this later
+	tracerName = "github.com/riandyrn/otelchi"
 )
 
 // Middleware sets up a handler to start tracing the incoming
@@ -32,7 +31,7 @@ func Middleware(serverName string, opts ...Option) func(next http.Handler) http.
 	}
 	tracer := cfg.TracerProvider.Tracer(
 		tracerName,
-		oteltrace.WithInstrumentationVersion(instrumentationVersion),
+		oteltrace.WithInstrumentationVersion(Version()),
 	)
 	if cfg.Propagators == nil {
 		cfg.Propagators = otel.GetTextMapPropagator()

--- a/test/cases/version_test.go
+++ b/test/cases/version_test.go
@@ -1,0 +1,20 @@
+package otelchi_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/riandyrn/otelchi"
+	"github.com/stretchr/testify/assert"
+)
+
+// regex taken from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+var versionRegex = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)` +
+	`(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)` +
+	`(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?` +
+	`(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
+
+func TestVersionSemver(t *testing.T) {
+	v := otelchi.Version()
+	assert.NotNil(t, versionRegex.FindStringSubmatch(v), "version is not semver: %s", v)
+}

--- a/version.go
+++ b/version.go
@@ -1,0 +1,6 @@
+package otelchi
+
+// Version is the current release version of otelchi in use.
+func Version() string {
+	return "0.6.0"
+}


### PR DESCRIPTION
**Changes Summary:**

- Add `CHANGELOG.md` so the various notable changes in the library are well documented and easier to understand.
- Add `RELEASING.md` so the maintainers can understand how to create releases.
- Add `CODEOWNERS` so the contributors know who to ask for review.
- Add `version.go` for containing the library version to follow the structural "convention" in otel instrumentation library.