### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [0.6.0] - 2024-04-02
 
+### ⚠️ Notice ⚠️
+
+This release is the last to support Go `1.15`. The next release will require at least Go `1.18`.
+
 ### Added
 
 - Add `WithTraceIDResponseHeader` option to enable adding trace id into response header. (#36)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.6.0] - 2024-04-02
+
 ### Added
 
-- Add `WithTraceResponseHeaderKey` option to set custom response header key. (#23)
+- Add `WithTraceIDResponseHeader` option to enable adding trace id into response header. (#36)
 - Add multiple go versions test scripts for local and CI pipeline. (#29)
 - Add compatibility testing for `ubuntu`, `macos` and `windows`. (#32)
 - Add repo essentials docs. (#33)
@@ -20,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Upgrade to `v5.0.12` of `go-chi/chi`. (#29)
 - Upgrade to `v1.10.0` of `go.opentelemetry.io/otel`. (#29)
 - Upgrade to `v1.12.0` of `go.opentelemetry.io/otel/semconv`. (#29)
+- Set the required go version for both `examples/basic` & `examples/multi-services` to `1.15`, `go-chi/chi` to `v5.0.12`, & `go.opentelemetry.io/otel` to `v1.10.0` (#35)
 
 ## [0.5.2] - 2024-03-25
 
@@ -111,7 +114,8 @@ It contains instrumentation for trace and depends on:
 - Example code for a basic usage.
 - Apache-2.0 license.
 
-[Unreleased]: https://github.com/riandyrn/otelchi/compare/v0.5.2...HEAD
+[Unreleased]: https://github.com/riandyrn/otelchi/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/riandyrn/otelchi/releases/tag/v0.6.0
 [0.5.2]: https://github.com/riandyrn/otelchi/releases/tag/v0.5.2
 [0.5.1]: https://github.com/riandyrn/otelchi/releases/tag/v0.5.1
 [0.5.0]: https://github.com/riandyrn/otelchi/releases/tag/v0.5.0

--- a/config.go
+++ b/config.go
@@ -8,6 +8,8 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
+const defaultTraceResponseHeaderKey = "X-Trace-Id"
+
 // config is used to configure the mux middleware.
 type config struct {
 	TracerProvider          oteltrace.TracerProvider
@@ -82,14 +84,13 @@ func WithFilter(filter func(r *http.Request) bool) Option {
 	})
 }
 
-// WithTraceResponseHeaderKey is used for changing response header key that contains trace id.
-// Instead of using a fixed name as the parameter, this function accepts a function
-// that takes a string (the default trace header) and returns a string (the custom trace header).
-// If the provided function is nil, the default trace header (X-Trace-ID) will be used.
+// WithTraceIDResponseHeader enables adding trace id into response header.
+// It accepts a function that generates the header key name. If this parameter
+// function set to `nil` the default header key which is `X-Trace-Id` will be used.
 func WithTraceIDResponseHeader(headerKeyFunc func() string) Option {
 	return optionFunc(func(cfg *config) {
 		if headerKeyFunc == nil {
-			cfg.TraceResponseHeaderKey = defaultTraceResponseHeaderKey // Default trace header
+			cfg.TraceResponseHeaderKey = defaultTraceResponseHeaderKey // use default trace header
 		} else {
 			cfg.TraceResponseHeaderKey = headerKeyFunc()
 		}

--- a/middleware.go
+++ b/middleware.go
@@ -16,8 +16,6 @@ import (
 
 const (
 	tracerName = "github.com/riandyrn/otelchi"
-
-	defaultTraceResponseHeaderKey = "X-Trace-ID"
 )
 
 // Middleware sets up a handler to start tracing the incoming


### PR DESCRIPTION
**Changes Summary:**

- Change `X-Trace-ID` into `X-Trace-Id` for the default trace ID response header key since this is the typical format
- Update comment for `WithTraceIDResponseHeader`
- Update the latest version in `CHANGELOG.md` to `v0.6.0`
- Update the log for `WithTraceResponseHeaderKey` into `WithTraceIDResponseHeader` in `v0.6.0` content