### PR TITLE
Feat: Improvement for Initial Implementation of Version 0.7.0

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -146,7 +146,7 @@ func (tw traceware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer span.End()
 
 	// put trace_id to response header only when WithTraceResponseHeaderKey is used
-	if tw.traceResponseHeaderKey != "" && span.SpanContext().HasTraceID() {
+	if len(tw.traceResponseHeaderKey) > 0 && span.SpanContext().HasTraceID() {
 		w.Header().Add(tw.traceResponseHeaderKey, span.SpanContext().TraceID().String())
 	}
 
@@ -169,7 +169,7 @@ func (tw traceware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// set status code attribute
-	span.SetAttributes(semconv.HTTPStatusCodeKey.Int(rrw.status))
+	span.SetAttributes(semconv.HTTPStatusCode(rrw.status))
 
 	// set span status
 	span.SetStatus(httpconv.ServerStatus(rrw.status))

--- a/middleware.go
+++ b/middleware.go
@@ -162,7 +162,7 @@ func (tw traceware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// during span creation
 	if len(routePattern) == 0 {
 		routePattern = chi.RouteContext(r.Context()).RoutePattern()
-		span.SetAttributes(semconv.HTTPRouteKey.String(routePattern))
+		span.SetAttributes(semconv.HTTPRoute(routePattern))
 
 		spanName = addPrefixToSpanName(tw.reqMethodInSpanName, r.Method, routePattern)
 		span.SetName(spanName)

--- a/middleware.go
+++ b/middleware.go
@@ -164,8 +164,7 @@ func (tw traceware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		span.SetName(spanName)
 	}
 
-	// set target and route attribute
-	span.SetAttributes(semconv.HTTPTargetKey.String(r.URL.Path))
+	// set route attribute
 	span.SetAttributes(semconv.HTTPRouteKey.String(routePattern))
 
 	// set status code attribute

--- a/test/cases/sdk_test.go
+++ b/test/cases/sdk_test.go
@@ -45,7 +45,6 @@ func TestSDKIntegration(t *testing.T) {
 				"foobar",
 				http.StatusOK,
 				"GET",
-				"/user/123",
 				"/user/{id:[0-9]+}",
 			),
 		},
@@ -56,7 +55,6 @@ func TestSDKIntegration(t *testing.T) {
 				"foobar",
 				http.StatusOK,
 				"GET",
-				"/book/foo",
 				"/book/{title}",
 			),
 		},
@@ -102,7 +100,6 @@ func TestSDKIntegrationWithFilters(t *testing.T) {
 				"foobar",
 				http.StatusOK,
 				"GET",
-				"/user/123",
 				"/user/{id:[0-9]+}",
 			),
 		},
@@ -113,7 +110,6 @@ func TestSDKIntegrationWithFilters(t *testing.T) {
 				"foobar",
 				http.StatusOK,
 				"GET",
-				"/book/foo",
 				"/book/{title}",
 			),
 		},
@@ -150,7 +146,6 @@ func TestSDKIntegrationWithChiRoutes(t *testing.T) {
 				"foobar",
 				http.StatusOK,
 				"GET",
-				"/user/123",
 				"/user/{id:[0-9]+}",
 			),
 		},
@@ -161,7 +156,6 @@ func TestSDKIntegrationWithChiRoutes(t *testing.T) {
 				"foobar",
 				http.StatusOK,
 				"GET",
-				"/book/foo",
 				"/book/{title}",
 			),
 		},
@@ -202,7 +196,6 @@ func TestSDKIntegrationOverrideSpanName(t *testing.T) {
 				"foobar",
 				http.StatusOK,
 				"GET",
-				"/user/123",
 				"/user/{id:[0-9]+}",
 			),
 		},
@@ -213,7 +206,6 @@ func TestSDKIntegrationOverrideSpanName(t *testing.T) {
 				"foobar",
 				http.StatusOK,
 				"GET",
-				"/book/foo",
 				"/book/{title}",
 			),
 		},
@@ -248,7 +240,6 @@ func TestSDKIntegrationWithRequestMethodInSpanName(t *testing.T) {
 				"foobar",
 				http.StatusOK,
 				"GET",
-				"/user/123",
 				"/user/{id:[0-9]+}",
 			),
 		},
@@ -259,7 +250,6 @@ func TestSDKIntegrationWithRequestMethodInSpanName(t *testing.T) {
 				"foobar",
 				http.StatusOK,
 				"GET",
-				"/book/foo",
 				"/book/{title}",
 			),
 		},
@@ -298,7 +288,6 @@ func TestSDKIntegrationEmptyHandlerDefaultStatusCode(t *testing.T) {
 				"foobar",
 				http.StatusOK,
 				"GET",
-				"/user/123",
 				"/user/{id:[0-9]+}",
 			),
 		},
@@ -309,7 +298,6 @@ func TestSDKIntegrationEmptyHandlerDefaultStatusCode(t *testing.T) {
 				"foobar",
 				http.StatusOK,
 				"GET",
-				"/book/foo",
 				"/book/{title}",
 			),
 		},
@@ -320,7 +308,6 @@ func TestSDKIntegrationEmptyHandlerDefaultStatusCode(t *testing.T) {
 				"foobar",
 				http.StatusNotFound,
 				"GET",
-				"/not-found",
 				"/not-found",
 			),
 		},
@@ -356,7 +343,6 @@ func TestSDKIntegrationRootHandler(t *testing.T) {
 				http.StatusOK,
 				"GET",
 				"/",
-				"/",
 			),
 		},
 	})
@@ -385,17 +371,21 @@ func TestSDKIntegrationWithOverrideHeaderKey(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r0)
 
-	require.Len(t, sr.Ended(), 1)
-	assertSpan(t, sr.Ended()[0],
-		"/user/{id:[0-9]+}",
-		trace.SpanKindServer,
-		attribute.String("net.host.name", "foobar"),
-		attribute.Int("http.status_code", http.StatusOK),
-		attribute.String("http.method", "GET"),
-		attribute.String("http.target", "/user/123"),
-		attribute.String("http.route", "/user/{id:[0-9]+}"),
-	)
-	require.Equal(t, w.Header().Get(customHeaderKeyFunc()), sr.Ended()[0].SpanContext().TraceID().String())
+	recordedSpans := sr.Ended()
+	require.Len(t, recordedSpans, 1)
+	checkSpans(t, recordedSpans, []spanValueCheck{
+		{
+			Name: "/user/{id:[0-9]+}",
+			Kind: trace.SpanKindServer,
+			Attributes: getSemanticAttributes(
+				"foobar",
+				http.StatusOK,
+				"GET",
+				"/user/{id:[0-9]+}",
+			),
+		},
+	})
+	require.Equal(t, w.Header().Get(customHeaderKeyFunc()), recordedSpans[0].SpanContext().TraceID().String())
 }
 
 func TestSDKIntegrationWithoutOverrideHeaderKey(t *testing.T) {
@@ -415,16 +405,21 @@ func TestSDKIntegrationWithoutOverrideHeaderKey(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r0)
 
-	require.Len(t, sr.Ended(), 1)
-	assertSpan(t, sr.Ended()[0],
-		"/user/{id:[0-9]+}",
-		trace.SpanKindServer,
-		attribute.String("net.host.name", "foobar"),
-		attribute.Int("http.status_code", http.StatusOK),
-		attribute.String("http.method", "GET"),
-		attribute.String("http.target", "/user/123"),
-		attribute.String("http.route", "/user/{id:[0-9]+}"),
-	)
+	recordedSpans := sr.Ended()
+	require.Len(t, recordedSpans, 1)
+
+	checkSpans(t, recordedSpans, []spanValueCheck{
+		{
+			Name: "/user/{id:[0-9]+}",
+			Kind: trace.SpanKindServer,
+			Attributes: getSemanticAttributes(
+				"foobar",
+				http.StatusOK,
+				"GET",
+				"/user/{id:[0-9]+}",
+			),
+		},
+	})
 
 	require.Empty(t, w.Header().Get("X-Trace-ID"))
 }
@@ -471,12 +466,11 @@ type spanValueCheck struct {
 	Attributes []attribute.KeyValue
 }
 
-func getSemanticAttributes(serverName string, httpStatusCode int, httpMethod, httpTarget, httpRoute string) []attribute.KeyValue {
+func getSemanticAttributes(serverName string, httpStatusCode int, httpMethod, httpRoute string) []attribute.KeyValue {
 	return []attribute.KeyValue{
 		attribute.String("net.host.name", serverName),
 		attribute.Int("http.status_code", httpStatusCode),
 		attribute.String("http.method", httpMethod),
-		attribute.String("http.target", httpTarget),
 		attribute.String("http.route", httpRoute),
 	}
 }

--- a/test/infras/Dockerfile
+++ b/test/infras/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:10.13
 
 RUN apt-get update && apt-get install -y \
 	gcc \

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package otelchi
 
 // Version is the current release version of otelchi in use.
 func Version() string {
-	return "0.6.0"
+	return "0.7.0"
 }


### PR DESCRIPTION
**Changes Summary:**

- Remove `http.target` attribute on implementation & tests based on [this comment](https://github.com/open-telemetry/opentelemetry-go/blob/v1.14.0/semconv/internal/v2/http.go#L160-L165).
- Attribute `http.route` will now be set during span creation whenever possible.
- Use helper method `semconv.HTTPStatusCode()` & `semconv.HTTPRoute()` in the middleware implementation.
- Update return value of `Version()` in `version.go` to `0.7.0`
- Set the base image tag from `debian:buster` to `debian:10.13` in Dockerfile for testing to make it always refer to the same version of Debian.