### PR TITLE
Feat: Add Response Modifier Option

### DIFF
--- a/config.go
+++ b/config.go
@@ -8,17 +8,21 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
-const defaultTraceResponseHeaderKey = "X-Trace-Id"
+const (
+	defaultTraceIDResponseHeaderKey      = "X-Trace-Id"
+	defaultTraceSampledResponseHeaderKey = "X-Trace-Sampled"
+)
 
 // config is used to configure the mux middleware.
 type config struct {
-	TracerProvider          oteltrace.TracerProvider
-	Propagators             propagation.TextMapPropagator
-	ChiRoutes               chi.Routes
-	RequestMethodInSpanName bool
-	Filters                 []Filter
-	TraceResponseHeaderKey  string
-	PublicEndpointFn        func(r *http.Request) bool
+	TracerProvider           oteltrace.TracerProvider
+	Propagators              propagation.TextMapPropagator
+	ChiRoutes                chi.Routes
+	RequestMethodInSpanName  bool
+	Filters                  []Filter
+	TraceIDResponseHeaderKey string
+	TraceSampledResponseKey  string
+	PublicEndpointFn         func(r *http.Request) bool
 }
 
 // Option specifies instrumentation configuration options.
@@ -32,7 +36,7 @@ func (o optionFunc) apply(c *config) {
 	o(c)
 }
 
-// Filter is a predicate used to determine whether a given http.request should
+// Filter is a predicate used to determine whether a given [http.Request] should
 // be traced. A Filter must return true if the request should be traced.
 type Filter func(*http.Request) bool
 
@@ -98,9 +102,9 @@ func WithFilter(filter Filter) Option {
 func WithTraceIDResponseHeader(headerKeyFunc func() string) Option {
 	return optionFunc(func(cfg *config) {
 		if headerKeyFunc == nil {
-			cfg.TraceResponseHeaderKey = defaultTraceResponseHeaderKey // use default trace header
+			cfg.TraceIDResponseHeaderKey = defaultTraceIDResponseHeaderKey // use default trace header
 		} else {
-			cfg.TraceResponseHeaderKey = headerKeyFunc()
+			cfg.TraceIDResponseHeaderKey = headerKeyFunc()
 		}
 	})
 }
@@ -138,7 +142,7 @@ func WithPublicEndpoint() Option {
 // incoming span context. Otherwise, the generated span will be set as the
 // child span of the incoming span context.
 //
-// Essentially it has the same functionality as WithPublicEndpoint but with
+// Essentially it has the same functionality as [WithPublicEndpoint] but with
 // more flexibility.
 func WithPublicEndpointFn(fn func(r *http.Request) bool) Option {
 	return optionFunc(func(cfg *config) {

--- a/config.go
+++ b/config.go
@@ -10,7 +10,7 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
-const defaultTraceResponseHeaderKey = "X-Trace-Id"
+const DefaultTraceResponseHeaderKey = "X-Trace-Id"
 
 // config is used to configure the mux middleware.
 type config struct {
@@ -168,9 +168,12 @@ func WithResponseModifier(modFunc ResponseModifier) Option {
 func ResponseModifierTraceIDResponseHeader(opt ResponseModifierTraceIDResponseHeaderOption) ResponseModifier {
 	return func(ctx context.Context, w http.ResponseWriter) {
 		// set the response header key
-		headerKey := defaultTraceResponseHeaderKey
+		headerKey := DefaultTraceResponseHeaderKey
 		if opt.HeaderKeyFunc != nil {
 			headerKey = opt.HeaderKeyFunc()
+			if len(headerKey) == 0 {
+				panic("header key must not be empty")
+			}
 		}
 
 		// set the trace id into response header, please note that even though the trace

--- a/config.go
+++ b/config.go
@@ -8,21 +8,17 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
-const (
-	defaultTraceIDResponseHeaderKey      = "X-Trace-Id"
-	defaultTraceSampledResponseHeaderKey = "X-Trace-Sampled"
-)
+const defaultTraceResponseHeaderKey = "X-Trace-Id"
 
 // config is used to configure the mux middleware.
 type config struct {
-	TracerProvider           oteltrace.TracerProvider
-	Propagators              propagation.TextMapPropagator
-	ChiRoutes                chi.Routes
-	RequestMethodInSpanName  bool
-	Filters                  []Filter
-	TraceIDResponseHeaderKey string
-	TraceSampledResponseKey  string
-	PublicEndpointFn         func(r *http.Request) bool
+	TracerProvider          oteltrace.TracerProvider
+	Propagators             propagation.TextMapPropagator
+	ChiRoutes               chi.Routes
+	RequestMethodInSpanName bool
+	Filters                 []Filter
+	TraceResponseHeaderKey  string
+	PublicEndpointFn        func(r *http.Request) bool
 }
 
 // Option specifies instrumentation configuration options.
@@ -36,7 +32,7 @@ func (o optionFunc) apply(c *config) {
 	o(c)
 }
 
-// Filter is a predicate used to determine whether a given [http.Request] should
+// Filter is a predicate used to determine whether a given http.request should
 // be traced. A Filter must return true if the request should be traced.
 type Filter func(*http.Request) bool
 
@@ -102,9 +98,9 @@ func WithFilter(filter Filter) Option {
 func WithTraceIDResponseHeader(headerKeyFunc func() string) Option {
 	return optionFunc(func(cfg *config) {
 		if headerKeyFunc == nil {
-			cfg.TraceIDResponseHeaderKey = defaultTraceIDResponseHeaderKey // use default trace header
+			cfg.TraceResponseHeaderKey = defaultTraceResponseHeaderKey // use default trace header
 		} else {
-			cfg.TraceIDResponseHeaderKey = headerKeyFunc()
+			cfg.TraceResponseHeaderKey = headerKeyFunc()
 		}
 	})
 }
@@ -142,7 +138,7 @@ func WithPublicEndpoint() Option {
 // incoming span context. Otherwise, the generated span will be set as the
 // child span of the incoming span context.
 //
-// Essentially it has the same functionality as [WithPublicEndpoint] but with
+// Essentially it has the same functionality as WithPublicEndpoint but with
 // more flexibility.
 func WithPublicEndpointFn(fn func(r *http.Request) bool) Option {
 	return optionFunc(func(cfg *config) {

--- a/config.go
+++ b/config.go
@@ -179,10 +179,10 @@ func ResponseModifierTraceIDResponseHeader(opt ResponseModifierTraceIDResponseHe
 		// set the trace id into response header, please note that even though the trace
 		// is not sampled, its id will be still set into the response header. If this
 		// behavior is not desirable you can create your own response modifier.
-		if span := oteltrace.SpanFromContext(ctx); span.SpanContext().HasTraceID() {
-			value := span.SpanContext().TraceID().String()
+		if spanCtx := oteltrace.SpanFromContext(ctx).SpanContext(); spanCtx.HasTraceID() {
+			value := spanCtx.TraceID().String()
 			if opt.IncludeSampledStatus {
-				value = fmt.Sprintf("%v; sampled=%v", value, span.SpanContext().IsSampled())
+				value = fmt.Sprintf("%v; sampled=%v", value, spanCtx.IsSampled())
 			}
 			w.Header().Set(headerKey, value)
 		}

--- a/config.go
+++ b/config.go
@@ -174,13 +174,13 @@ func ResponseModifierTraceIDResponseHeader(opt ResponseModifierTraceIDResponseHe
 		panic(err)
 	}
 
-	return func(ctx context.Context, w http.ResponseWriter) {
-		// set the response header key
-		headerKey := DefaultTraceResponseHeaderKey
-		if opt.HeaderKeyFunc != nil {
-			headerKey = opt.HeaderKeyFunc()
-		}
+	// set the response header key
+	headerKey := DefaultTraceResponseHeaderKey
+	if opt.HeaderKeyFunc != nil {
+		headerKey = opt.HeaderKeyFunc()
+	}
 
+	return func(ctx context.Context, w http.ResponseWriter) {
 		// set the trace id into response header, please note that even though the trace
 		// is not sampled, its id will be still set into the response header. If this
 		// behavior is not desirable you can create your own response modifier.

--- a/middleware.go
+++ b/middleware.go
@@ -2,6 +2,7 @@ package otelchi
 
 import (
 	"net/http"
+	"strconv"
 	"sync"
 
 	"github.com/felixge/httpsnoop"
@@ -23,7 +24,9 @@ const (
 // requests. The serverName parameter should describe the name of the
 // (virtual) server handling the request.
 func Middleware(serverName string, opts ...Option) func(next http.Handler) http.Handler {
-	cfg := config{}
+	cfg := config{
+		TraceSampledResponseKey: defaultTraceSampledResponseHeaderKey,
+	}
 	for _, opt := range opts {
 		opt.apply(&cfg)
 	}
@@ -40,29 +43,31 @@ func Middleware(serverName string, opts ...Option) func(next http.Handler) http.
 
 	return func(handler http.Handler) http.Handler {
 		return traceware{
-			serverName:             serverName,
-			tracer:                 tracer,
-			propagators:            cfg.Propagators,
-			handler:                handler,
-			chiRoutes:              cfg.ChiRoutes,
-			reqMethodInSpanName:    cfg.RequestMethodInSpanName,
-			filters:                cfg.Filters,
-			traceResponseHeaderKey: cfg.TraceResponseHeaderKey,
-			publicEndpointFn:       cfg.PublicEndpointFn,
+			serverName:               serverName,
+			tracer:                   tracer,
+			propagators:              cfg.Propagators,
+			handler:                  handler,
+			chiRoutes:                cfg.ChiRoutes,
+			reqMethodInSpanName:      cfg.RequestMethodInSpanName,
+			filters:                  cfg.Filters,
+			traceIDResponseHeaderKey: cfg.TraceIDResponseHeaderKey,
+			traceSampledResponseKey:  cfg.TraceSampledResponseKey,
+			publicEndpointFn:         cfg.PublicEndpointFn,
 		}
 	}
 }
 
 type traceware struct {
-	serverName             string
-	tracer                 oteltrace.Tracer
-	propagators            propagation.TextMapPropagator
-	handler                http.Handler
-	chiRoutes              chi.Routes
-	reqMethodInSpanName    bool
-	filters                []Filter
-	traceResponseHeaderKey string
-	publicEndpointFn       func(r *http.Request) bool
+	serverName               string
+	tracer                   oteltrace.Tracer
+	propagators              propagation.TextMapPropagator
+	handler                  http.Handler
+	chiRoutes                chi.Routes
+	reqMethodInSpanName      bool
+	filters                  []Filter
+	traceIDResponseHeaderKey string
+	traceSampledResponseKey  string
+	publicEndpointFn         func(r *http.Request) bool
 }
 
 type recordingResponseWriter struct {
@@ -175,9 +180,10 @@ func (tw traceware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx, span := tw.tracer.Start(ctx, spanName, spanOpts...)
 	defer span.End()
 
-	// put trace_id to response header only when WithTraceResponseHeaderKey is used
-	if len(tw.traceResponseHeaderKey) > 0 && span.SpanContext().HasTraceID() {
-		w.Header().Add(tw.traceResponseHeaderKey, span.SpanContext().TraceID().String())
+	// put trace_id to response header only when [WithTraceIDResponseHeader] is used
+	if len(tw.traceIDResponseHeaderKey) > 0 && span.SpanContext().HasTraceID() {
+		w.Header().Add(tw.traceIDResponseHeaderKey, span.SpanContext().TraceID().String())
+		w.Header().Add(tw.traceSampledResponseKey, strconv.FormatBool(span.SpanContext().IsSampled()))
 	}
 
 	// get recording response writer

--- a/test/cases/sdk_test.go
+++ b/test/cases/sdk_test.go
@@ -819,6 +819,16 @@ func TestSDKIntegrationWithResponseModifier(t *testing.T) {
 	}
 }
 
+func TestSDKIntegrationResponseModifierTraceIDResponseHeaderInvalidOption(t *testing.T) {
+	require.Panics(t, func() {
+		// define response modifier with header key func that returns empty string
+		// this should trigger panic because the option is invalid.
+		otelchi.ResponseModifierTraceIDResponseHeader(otelchi.ResponseModifierTraceIDResponseHeaderOption{
+			HeaderKeyFunc: func() string { return "" },
+		})
+	})
+}
+
 func assertSpan(t *testing.T, span sdktrace.ReadOnlySpan, name string, kind trace.SpanKind, attrs ...attribute.KeyValue) {
 	assert.Equal(t, name, span.Name())
 	assert.Equal(t, kind, span.SpanKind())

--- a/test/cases/sdk_test.go
+++ b/test/cases/sdk_test.go
@@ -454,7 +454,7 @@ func TestSDKIntegrationWithTraceIDResponseHeader(t *testing.T) {
 	}
 }
 
-func TestSDKIntegrationWithoutOverrideHeaderKey(t *testing.T) {
+func TestSDKIntegrationWithoutWithTraceIDResponseHeader(t *testing.T) {
 	router, sr := newSDKTestRouter("foobar", true)
 
 	router.HandleFunc("/user/{id:[0-9]+}", ok)
@@ -480,7 +480,7 @@ func TestSDKIntegrationWithoutOverrideHeaderKey(t *testing.T) {
 		},
 	})
 
-	require.Empty(t, w.Header().Get("X-Trace-ID"))
+	require.Empty(t, w.Header().Get(otelchi.DefaultTraceResponseHeaderKey))
 }
 
 func TestWithPublicEndpoint(t *testing.T) {


### PR DESCRIPTION
This PR offers a new option called `WithResponseModifier`, which allows end-users to modify the middleware's response.

So in the scenario mentioned in [#56](https://github.com/riandyrn/otelchi/pull/56#issuecomment-2242637749), the end user could create their own modifier just like demonstrated [here](https://github.com/riandyrn/otelchi/blob/e4c84b30d12c744750a0224a8209485dfa60fc63/test/cases/sdk_test.go#L744-L803).

In addition to adding the `WithResponseModifier` option, I also created a predefined modifier called `ResponseModifierTraceIDResponseHeader`. It allows the end user to show the trace ID in the response header along with its sampled status, catering to the use case I mentioned [here](https://github.com/riandyrn/otelchi/pull/56#issuecomment-2230854132).