### PR TITLE
refactor: reduce duplication by embedding config in traceware

### DIFF
--- a/config.go
+++ b/config.go
@@ -8,17 +8,21 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
-const defaultTraceResponseHeaderKey = "X-Trace-Id"
+const (
+	defaultTraceIDResponseHeaderKey      = "X-Trace-Id"
+	defaultTraceSampledResponseHeaderKey = "X-Trace-Sampled"
+)
 
 // config is used to configure the mux middleware.
 type config struct {
-	TracerProvider          oteltrace.TracerProvider
-	Propagators             propagation.TextMapPropagator
-	ChiRoutes               chi.Routes
-	RequestMethodInSpanName bool
-	Filters                 []Filter
-	TraceResponseHeaderKey  string
-	PublicEndpointFn        func(r *http.Request) bool
+	TracerProvider           oteltrace.TracerProvider
+	Propagators              propagation.TextMapPropagator
+	ChiRoutes                chi.Routes
+	RequestMethodInSpanName  bool
+	Filters                  []Filter
+	TraceIDResponseHeaderKey string
+	TraceSampledResponseKey  string
+	PublicEndpointFn         func(r *http.Request) bool
 }
 
 // Option specifies instrumentation configuration options.
@@ -32,7 +36,7 @@ func (o optionFunc) apply(c *config) {
 	o(c)
 }
 
-// Filter is a predicate used to determine whether a given http.request should
+// Filter is a predicate used to determine whether a given [http.Request] should
 // be traced. A Filter must return true if the request should be traced.
 type Filter func(*http.Request) bool
 
@@ -98,9 +102,9 @@ func WithFilter(filter Filter) Option {
 func WithTraceIDResponseHeader(headerKeyFunc func() string) Option {
 	return optionFunc(func(cfg *config) {
 		if headerKeyFunc == nil {
-			cfg.TraceResponseHeaderKey = defaultTraceResponseHeaderKey // use default trace header
+			cfg.TraceIDResponseHeaderKey = defaultTraceIDResponseHeaderKey // use default trace header
 		} else {
-			cfg.TraceResponseHeaderKey = headerKeyFunc()
+			cfg.TraceIDResponseHeaderKey = headerKeyFunc()
 		}
 	})
 }
@@ -138,7 +142,7 @@ func WithPublicEndpoint() Option {
 // incoming span context. Otherwise, the generated span will be set as the
 // child span of the incoming span context.
 //
-// Essentially it has the same functionality as WithPublicEndpoint but with
+// Essentially it has the same functionality as [WithPublicEndpoint] but with
 // more flexibility.
 func WithPublicEndpointFn(fn func(r *http.Request) bool) Option {
 	return optionFunc(func(cfg *config) {

--- a/config.go
+++ b/config.go
@@ -16,14 +16,14 @@ const (
 
 // config is used to configure the mux middleware.
 type config struct {
-	TracerProvider                oteltrace.TracerProvider
-	Propagators                   propagation.TextMapPropagator
-	ChiRoutes                     chi.Routes
-	RequestMethodInSpanName       bool
-	Filters                       []Filter
-	TraceIDResponseHeaderKey      string
-	TraceSampledResponseHeaderKey string
-	PublicEndpointFn              func(r *http.Request) bool
+	tracerProvider                oteltrace.TracerProvider
+	propagators                   propagation.TextMapPropagator
+	chiRoutes                     chi.Routes
+	requestMethodInSpanName       bool
+	filters                       []Filter
+	traceIDResponseHeaderKey      string
+	traceSampledResponseHeaderKey string
+	publicEndpointFn              func(r *http.Request) bool
 }
 
 // Option specifies instrumentation configuration options.
@@ -46,7 +46,7 @@ type Filter func(*http.Request) bool
 // ones will be used.
 func WithPropagators(propagators propagation.TextMapPropagator) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.Propagators = propagators
+		cfg.propagators = propagators
 	})
 }
 
@@ -54,7 +54,7 @@ func WithPropagators(propagators propagation.TextMapPropagator) Option {
 // If none is specified, the global provider is used.
 func WithTracerProvider(provider oteltrace.TracerProvider) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.TracerProvider = provider
+		cfg.tracerProvider = provider
 	})
 }
 
@@ -66,7 +66,7 @@ func WithTracerProvider(provider oteltrace.TracerProvider) Option {
 // is possible for them to override the span name.
 func WithChiRoutes(routes chi.Routes) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.ChiRoutes = routes
+		cfg.chiRoutes = routes
 	})
 }
 
@@ -81,7 +81,7 @@ func WithChiRoutes(routes chi.Routes) Option {
 // - https://github.com/riandyrn/otelchi/issues/6#issuecomment-1034461912
 func WithRequestMethodInSpanName(isActive bool) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.RequestMethodInSpanName = isActive
+		cfg.requestMethodInSpanName = isActive
 	})
 }
 
@@ -93,7 +93,7 @@ func WithRequestMethodInSpanName(isActive bool) Option {
 // simple and fast.
 func WithFilter(filter Filter) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.Filters = append(cfg.Filters, filter)
+		cfg.filters = append(cfg.filters, filter)
 	})
 }
 
@@ -105,9 +105,9 @@ func WithFilter(filter Filter) Option {
 func WithTraceIDResponseHeader(headerKeyFunc func() string) Option {
 	return optionFunc(func(cfg *config) {
 		if headerKeyFunc == nil {
-			cfg.TraceIDResponseHeaderKey = defaultTraceIDResponseHeaderKey // use default trace header
+			cfg.traceIDResponseHeaderKey = defaultTraceIDResponseHeaderKey // use default trace header
 		} else {
-			cfg.TraceIDResponseHeaderKey = headerKeyFunc()
+			cfg.traceIDResponseHeaderKey = headerKeyFunc()
 		}
 	})
 }
@@ -119,14 +119,14 @@ type TraceHeaderConfig struct {
 
 func WithTraceResponseHeaders(cfg TraceHeaderConfig) Option {
 	return optionFunc(func(c *config) {
-		c.TraceIDResponseHeaderKey = cfg.TraceIDHeader
-		if c.TraceIDResponseHeaderKey == "" {
-			c.TraceIDResponseHeaderKey = defaultTraceIDResponseHeaderKey
+		c.traceIDResponseHeaderKey = cfg.TraceIDHeader
+		if c.traceIDResponseHeaderKey == "" {
+			c.traceIDResponseHeaderKey = defaultTraceIDResponseHeaderKey
 		}
 
-		c.TraceSampledResponseHeaderKey = cfg.TraceSampledHeader
-		if c.TraceSampledResponseHeaderKey == "" {
-			c.TraceSampledResponseHeaderKey = defaultTraceSampledResponseHeaderKey
+		c.traceSampledResponseHeaderKey = cfg.TraceSampledHeader
+		if c.traceSampledResponseHeaderKey == "" {
+			c.traceSampledResponseHeaderKey = defaultTraceSampledResponseHeaderKey
 		}
 	})
 }
@@ -168,6 +168,6 @@ func WithPublicEndpoint() Option {
 // more flexibility.
 func WithPublicEndpointFn(fn func(r *http.Request) bool) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.PublicEndpointFn = fn
+		cfg.publicEndpointFn = fn
 	})
 }

--- a/middleware.go
+++ b/middleware.go
@@ -2,6 +2,7 @@ package otelchi
 
 import (
 	"net/http"
+	"strconv"
 	"sync"
 
 	"github.com/felixge/httpsnoop"
@@ -23,7 +24,9 @@ const (
 // requests. The serverName parameter should describe the name of the
 // (virtual) server handling the request.
 func Middleware(serverName string, opts ...Option) func(next http.Handler) http.Handler {
-	cfg := config{}
+	cfg := config{
+		TraceSampledResponseKey: defaultTraceSampledResponseHeaderKey,
+	}
 	for _, opt := range opts {
 		opt.apply(&cfg)
 	}
@@ -40,29 +43,31 @@ func Middleware(serverName string, opts ...Option) func(next http.Handler) http.
 
 	return func(handler http.Handler) http.Handler {
 		return traceware{
-			serverName:             serverName,
-			tracer:                 tracer,
-			propagators:            cfg.Propagators,
-			handler:                handler,
-			chiRoutes:              cfg.ChiRoutes,
-			reqMethodInSpanName:    cfg.RequestMethodInSpanName,
-			filters:                cfg.Filters,
-			traceResponseHeaderKey: cfg.TraceResponseHeaderKey,
-			publicEndpointFn:       cfg.PublicEndpointFn,
+			serverName:               serverName,
+			tracer:                   tracer,
+			propagators:              cfg.Propagators,
+			handler:                  handler,
+			chiRoutes:                cfg.ChiRoutes,
+			reqMethodInSpanName:      cfg.RequestMethodInSpanName,
+			filters:                  cfg.Filters,
+			traceIDResponseHeaderKey: cfg.TraceIDResponseHeaderKey,
+			traceSampledResponseKey:  cfg.TraceSampledResponseKey,
+			publicEndpointFn:         cfg.PublicEndpointFn,
 		}
 	}
 }
 
 type traceware struct {
-	serverName             string
-	tracer                 oteltrace.Tracer
-	propagators            propagation.TextMapPropagator
-	handler                http.Handler
-	chiRoutes              chi.Routes
-	reqMethodInSpanName    bool
-	filters                []Filter
-	traceResponseHeaderKey string
-	publicEndpointFn       func(r *http.Request) bool
+	serverName               string
+	tracer                   oteltrace.Tracer
+	propagators              propagation.TextMapPropagator
+	handler                  http.Handler
+	chiRoutes                chi.Routes
+	reqMethodInSpanName      bool
+	filters                  []Filter
+	traceIDResponseHeaderKey string
+	traceSampledResponseKey  string
+	publicEndpointFn         func(r *http.Request) bool
 }
 
 type recordingResponseWriter struct {
@@ -175,9 +180,10 @@ func (tw traceware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx, span := tw.tracer.Start(ctx, spanName, spanOpts...)
 	defer span.End()
 
-	// put trace_id to response header only when WithTraceResponseHeaderKey is used
-	if len(tw.traceResponseHeaderKey) > 0 && span.SpanContext().HasTraceID() {
-		w.Header().Add(tw.traceResponseHeaderKey, span.SpanContext().TraceID().String())
+	// put trace_id to response header only when [WithTraceIDResponseHeader] is used
+	if len(tw.traceIDResponseHeaderKey) > 0 && span.SpanContext().HasTraceID() {
+		w.Header().Add(tw.traceIDResponseHeaderKey, span.SpanContext().TraceID().String())
+		w.Header().Add(tw.traceSampledResponseKey, strconv.FormatBool(span.SpanContext().IsSampled()))
 	}
 
 	// get recording response writer

--- a/middleware.go
+++ b/middleware.go
@@ -28,44 +28,32 @@ func Middleware(serverName string, opts ...Option) func(next http.Handler) http.
 	for _, opt := range opts {
 		opt.apply(&cfg)
 	}
-	if cfg.TracerProvider == nil {
-		cfg.TracerProvider = otel.GetTracerProvider()
+	if cfg.tracerProvider == nil {
+		cfg.tracerProvider = otel.GetTracerProvider()
 	}
-	tracer := cfg.TracerProvider.Tracer(
+	tracer := cfg.tracerProvider.Tracer(
 		tracerName,
 		oteltrace.WithInstrumentationVersion(Version()),
 	)
-	if cfg.Propagators == nil {
-		cfg.Propagators = otel.GetTextMapPropagator()
+	if cfg.propagators == nil {
+		cfg.propagators = otel.GetTextMapPropagator()
 	}
 
 	return func(handler http.Handler) http.Handler {
 		return traceware{
-			serverName:                    serverName,
-			tracer:                        tracer,
-			propagators:                   cfg.Propagators,
-			handler:                       handler,
-			chiRoutes:                     cfg.ChiRoutes,
-			reqMethodInSpanName:           cfg.RequestMethodInSpanName,
-			filters:                       cfg.Filters,
-			traceIDResponseHeaderKey:      cfg.TraceIDResponseHeaderKey,
-			traceSampledResponseHeaderKey: cfg.TraceSampledResponseHeaderKey,
-			publicEndpointFn:              cfg.PublicEndpointFn,
+			config:     cfg,
+			serverName: serverName,
+			tracer:     tracer,
+			handler:    handler,
 		}
 	}
 }
 
 type traceware struct {
-	serverName                    string
-	tracer                        oteltrace.Tracer
-	propagators                   propagation.TextMapPropagator
-	handler                       http.Handler
-	chiRoutes                     chi.Routes
-	reqMethodInSpanName           bool
-	filters                       []Filter
-	traceIDResponseHeaderKey      string
-	traceSampledResponseHeaderKey string
-	publicEndpointFn              func(r *http.Request) bool
+	config
+	serverName string
+	tracer     oteltrace.Tracer
+	handler    http.Handler
 }
 
 type recordingResponseWriter struct {
@@ -142,7 +130,7 @@ func (tw traceware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		rctx := chi.NewRouteContext()
 		if tw.chiRoutes.Match(rctx, r.Method, r.URL.Path) {
 			routePattern = rctx.RoutePattern()
-			spanName = addPrefixToSpanName(tw.reqMethodInSpanName, r.Method, routePattern)
+			spanName = addPrefixToSpanName(tw.requestMethodInSpanName, r.Method, routePattern)
 			spanAttributes = append(spanAttributes, semconv.HTTPRoute(routePattern))
 		}
 	}
@@ -198,7 +186,7 @@ func (tw traceware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		routePattern = chi.RouteContext(r.Context()).RoutePattern()
 		span.SetAttributes(semconv.HTTPRoute(routePattern))
 
-		spanName = addPrefixToSpanName(tw.reqMethodInSpanName, r.Method, routePattern)
+		spanName = addPrefixToSpanName(tw.requestMethodInSpanName, r.Method, routePattern)
 		span.SetName(spanName)
 	}
 


### PR DESCRIPTION
This small refactoring MR was split from #59

It slightly reduces code duplication by directly embedding a shallow copy of the config into the `traceware`.