### PR TITLE
Release v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.10.1] - 2024-10-27
+
+### Changed
+
+- Upgrade `go.opentelemetry.io/otel`, `go.opentelemetry.io/otel/sdk`, & `go.opentelemetry.io/otel/trace` to `v1.30.0`. ([#70])
+
+### Fixed
+
+- Span for websocket connection now won't be marked as error span. ([#67])
+
 ## [0.10.0] - 2024-09-17
 
 ### Added
@@ -194,6 +204,8 @@ It contains instrumentation for trace and depends on:
 - Example code for a basic usage.
 - Apache-2.0 license.
 
+[#70]: https://github.com/riandyrn/otelchi/pull/70
+[#67]: https://github.com/riandyrn/otelchi/pull/67
 [#64]: https://github.com/riandyrn/otelchi/pull/64
 [#63]: https://github.com/riandyrn/otelchi/pull/63
 [#62]: https://github.com/riandyrn/otelchi/pull/62
@@ -219,7 +231,8 @@ It contains instrumentation for trace and depends on:
 [#2]: https://github.com/riandyrn/otelchi/pull/2
 [#1]: https://github.com/riandyrn/otelchi/pull/1
 
-[Unreleased]: https://github.com/riandyrn/otelchi/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/riandyrn/otelchi/compare/v0.10.1...HEAD
+[0.10.1]: https://github.com/riandyrn/otelchi/releases/tag/v0.10.1
 [0.10.0]: https://github.com/riandyrn/otelchi/releases/tag/v0.10.0
 [0.9.0]: https://github.com/riandyrn/otelchi/releases/tag/v0.9.0
 [0.8.0]: https://github.com/riandyrn/otelchi/releases/tag/v0.8.0

--- a/examples/basic/go.mod
+++ b/examples/basic/go.mod
@@ -6,7 +6,7 @@ replace github.com/riandyrn/otelchi => ../../
 
 require (
 	github.com/go-chi/chi/v5 v5.1.0
-	github.com/riandyrn/otelchi v0.10.0
+	github.com/riandyrn/otelchi v0.10.1
 	go.opentelemetry.io/otel v1.31.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.31.0
 	go.opentelemetry.io/otel/sdk v1.31.0

--- a/examples/multi-services/go.mod
+++ b/examples/multi-services/go.mod
@@ -6,7 +6,7 @@ replace github.com/riandyrn/otelchi => ../../
 
 require (
 	github.com/go-chi/chi/v5 v5.1.0
-	github.com/riandyrn/otelchi v0.10.0
+	github.com/riandyrn/otelchi v0.10.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.56.0
 	go.opentelemetry.io/otel v1.31.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.31.0

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package otelchi
 
 // Version is the current release version of otelchi in use.
 func Version() string {
-	return "0.10.0"
+	return "0.10.1"
 }


### PR DESCRIPTION
- Update the returned value of `Version()` to `v0.10.1`
- Update dependencies example to use `v0.10.1`
- Update CHANGELOG.md