### PR TITLE
Fix: Make Metric Meter Public

### DIFF
--- a/metric/config.go
+++ b/metric/config.go
@@ -18,10 +18,10 @@ const (
 type BaseConfig struct {
 	// for initialization
 	meterProvider otelmetric.MeterProvider
-	serverName    string
 
 	// actual config state
-	Meter otelmetric.Meter
+	Meter      otelmetric.Meter
+	ServerName string
 }
 
 // Option specifies instrumentation configuration options.
@@ -45,7 +45,9 @@ func WithMeterProvider(provider otelmetric.MeterProvider) Option {
 
 func NewBaseConfig(serverName string, opts ...Option) BaseConfig {
 	// init base config
-	cfg := BaseConfig{}
+	cfg := BaseConfig{
+		ServerName: serverName,
+	}
 	for _, opt := range opts {
 		opt.apply(&cfg)
 	}

--- a/metric/config.go
+++ b/metric/config.go
@@ -18,10 +18,10 @@ const (
 type BaseConfig struct {
 	// for initialization
 	meterProvider otelmetric.MeterProvider
+	serverName    string
 
 	// actual config state
-	meter      otelmetric.Meter
-	serverName string
+	Meter otelmetric.Meter
 }
 
 // Option specifies instrumentation configuration options.
@@ -53,7 +53,7 @@ func NewBaseConfig(serverName string, opts ...Option) BaseConfig {
 	if cfg.meterProvider == nil {
 		cfg.meterProvider = otel.GetMeterProvider()
 	}
-	cfg.meter = cfg.meterProvider.Meter(
+	cfg.Meter = cfg.meterProvider.Meter(
 		ScopeName,
 		otelmetric.WithSchemaURL(semconv.SchemaURL),
 		otelmetric.WithInstrumentationVersion(Version()),

--- a/metric/request_duration.go
+++ b/metric/request_duration.go
@@ -17,7 +17,7 @@ const (
 
 func NewRequestDurationMillis(cfg BaseConfig) func(next http.Handler) http.Handler {
 	// init metric, here we are using histogram for capturing request duration
-	histogram, err := cfg.meter.Int64Histogram(
+	histogram, err := cfg.Meter.Int64Histogram(
 		metricNameRequestDurationMs,
 		otelmetric.WithDescription(metricDescRequestDurationMs),
 		otelmetric.WithUnit(metricUnitRequestDurationMs),

--- a/metric/request_duration.go
+++ b/metric/request_duration.go
@@ -40,7 +40,7 @@ func NewRequestDurationMillis(cfg BaseConfig) func(next http.Handler) http.Handl
 				r.Context(),
 				int64(duration.Milliseconds()),
 				otelmetric.WithAttributes(
-					httpconv.ServerRequest(cfg.serverName, r)...,
+					httpconv.ServerRequest(cfg.ServerName, r)...,
 				),
 			)
 		})

--- a/metric/requests_inflight.go
+++ b/metric/requests_inflight.go
@@ -30,7 +30,7 @@ func NewRequestInFlight(cfg BaseConfig) func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// increase the number of requests in flight
 			counter.Add(r.Context(), 1, otelmetric.WithAttributes(
-				httpconv.ServerRequest(cfg.serverName, r)...,
+				httpconv.ServerRequest(cfg.ServerName, r)...,
 			))
 
 			// execute next http handler
@@ -38,7 +38,7 @@ func NewRequestInFlight(cfg BaseConfig) func(next http.Handler) http.Handler {
 
 			// decrease the number of requests in flight
 			counter.Add(r.Context(), -1, otelmetric.WithAttributes(
-				httpconv.ServerRequest(cfg.serverName, r)...,
+				httpconv.ServerRequest(cfg.ServerName, r)...,
 			))
 		})
 	}

--- a/metric/requests_inflight.go
+++ b/metric/requests_inflight.go
@@ -28,18 +28,17 @@ func NewRequestInFlight(cfg BaseConfig) func(next http.Handler) http.Handler {
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// define metric attributes
+			attrs := otelmetric.WithAttributes(httpconv.ServerRequest(cfg.ServerName, r)...)
+
 			// increase the number of requests in flight
-			counter.Add(r.Context(), 1, otelmetric.WithAttributes(
-				httpconv.ServerRequest(cfg.ServerName, r)...,
-			))
+			counter.Add(r.Context(), 1, attrs)
 
 			// execute next http handler
 			next.ServeHTTP(w, r)
 
 			// decrease the number of requests in flight
-			counter.Add(r.Context(), -1, otelmetric.WithAttributes(
-				httpconv.ServerRequest(cfg.ServerName, r)...,
-			))
+			counter.Add(r.Context(), -1, attrs)
 		})
 	}
 }

--- a/metric/requests_inflight.go
+++ b/metric/requests_inflight.go
@@ -17,7 +17,7 @@ const (
 // [RequestInFlight] is a metrics recorder for recording the number of requests in flight.
 func NewRequestInFlight(cfg BaseConfig) func(next http.Handler) http.Handler {
 	// init metric, here we are using counter for capturing request in flight
-	counter, err := cfg.meter.Int64UpDownCounter(
+	counter, err := cfg.Meter.Int64UpDownCounter(
 		metricNameRequestInFlight,
 		otelmetric.WithDescription(metricDescRequestInFlight),
 		otelmetric.WithUnit(metricUnitRequestInFlight),

--- a/metric/response_size.go
+++ b/metric/response_size.go
@@ -39,7 +39,7 @@ func NewResponseSizeBytes(cfg BaseConfig) func(next http.Handler) http.Handler {
 				r.Context(),
 				int64(rrw.writtenBytes),
 				otelmetric.WithAttributes(
-					httpconv.ServerRequest(cfg.serverName, r)...,
+					httpconv.ServerRequest(cfg.ServerName, r)...,
 				),
 			)
 		})

--- a/metric/response_size.go
+++ b/metric/response_size.go
@@ -16,7 +16,7 @@ const (
 
 func NewResponseSizeBytes(cfg BaseConfig) func(next http.Handler) http.Handler {
 	// init metric, here we are using histogram for capturing response size
-	histogram, err := cfg.meter.Int64Histogram(
+	histogram, err := cfg.Meter.Int64Histogram(
 		metricNameResponseSizeBytes,
 		otelmetric.WithDescription(metricDescResponseSizeBytes),
 		otelmetric.WithUnit(metricUnitResponseSizeBytes),


### PR DESCRIPTION
Since we want to provide flexibility for end users to create their own middleware, we should make `metric.BaseConfig` available to be used by them.

So in this PR, I make `Meter` & `ServerName` available as public since these two are used in downstream middlewares.