### PR TITLE
Release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- Add metric package as middleware `go-chi/chi`, currently only support `request_duration_milliseconds`, `requests_inflight`, and `response_size_bytes` metric. ([#69])
+- Add metric package as middleware `go-chi/chi`, support `request_duration_millis`, `requests_inflight`, and `response_size_bytes` metric. ([#69])
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Add metric package as middleware `go-chi/chi`, support `request_duration_millis`, `requests_inflight`, and `response_size_bytes` metric. ([#69])
 
-### Removed
+### Changed
 
-- Remove duplication of traceware state by shallow copy the config. ([#75])
+- Upgrade `go.opentelemetry.io/otel`, `go.opentelemetry.io/otel/sdk`, & `go.opentelemetry.io/otel/trace` to `v1.32.0`. ([#74])
 
 ## [0.10.1] - 2024-10-27
 
@@ -214,7 +214,7 @@ It contains instrumentation for trace and depends on:
 - Example code for a basic usage.
 - Apache-2.0 license.
 
-[#75]: https://github.com/riandyrn/otelchi/pull/75
+[#74]: https://github.com/riandyrn/otelchi/pull/74
 [#70]: https://github.com/riandyrn/otelchi/pull/70
 [#69]: https://github.com/riandyrn/otelchi/pull/69
 [#67]: https://github.com/riandyrn/otelchi/pull/67

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.11.0] - 2024-11-27
+
+### Added
+
+- Add metric package as middleware `go-chi/chi`, currently only support `request_duration_milliseconds`, `requests_inflight`, and `response_size_bytes` metric. ([#69])
+
+### Removed
+
+- Remove duplication of traceware state by shallow copy the config. ([#75])
+
 ## [0.10.1] - 2024-10-27
 
 ### Changed
@@ -204,7 +214,9 @@ It contains instrumentation for trace and depends on:
 - Example code for a basic usage.
 - Apache-2.0 license.
 
+[#75]: https://github.com/riandyrn/otelchi/pull/75
 [#70]: https://github.com/riandyrn/otelchi/pull/70
+[#69]: https://github.com/riandyrn/otelchi/pull/69
 [#67]: https://github.com/riandyrn/otelchi/pull/67
 [#64]: https://github.com/riandyrn/otelchi/pull/64
 [#63]: https://github.com/riandyrn/otelchi/pull/63
@@ -231,7 +243,8 @@ It contains instrumentation for trace and depends on:
 [#2]: https://github.com/riandyrn/otelchi/pull/2
 [#1]: https://github.com/riandyrn/otelchi/pull/1
 
-[Unreleased]: https://github.com/riandyrn/otelchi/compare/v0.10.1...HEAD
+[Unreleased]: https://github.com/riandyrn/otelchi/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/riandyrn/otelchi/releases/tag/v0.11.0
 [0.10.1]: https://github.com/riandyrn/otelchi/releases/tag/v0.10.1
 [0.10.0]: https://github.com/riandyrn/otelchi/releases/tag/v0.10.0
 [0.9.0]: https://github.com/riandyrn/otelchi/releases/tag/v0.9.0

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ OpenTelemetry instrumentation for [go-chi/chi](https://github.com/go-chi/chi).
 
 Essentially this is an adaptation from [otelmux](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/github.com/gorilla/mux/otelmux) but instead of using `gorilla/mux`, we use `go-chi/chi`.
 
-Currently, this library can only instrument traces.
+Currently, this library can only instrument traces and metrics.
 
 Contributions are welcomed!
 

--- a/examples/basic/go.mod
+++ b/examples/basic/go.mod
@@ -6,7 +6,7 @@ replace github.com/riandyrn/otelchi => ../../
 
 require (
 	github.com/go-chi/chi/v5 v5.1.0
-	github.com/riandyrn/otelchi v0.10.1
+	github.com/riandyrn/otelchi v0.11.0
 	go.opentelemetry.io/otel v1.32.0
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.32.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.32.0

--- a/examples/multi-services/go.mod
+++ b/examples/multi-services/go.mod
@@ -6,7 +6,7 @@ replace github.com/riandyrn/otelchi => ../../
 
 require (
 	github.com/go-chi/chi/v5 v5.1.0
-	github.com/riandyrn/otelchi v0.10.1
+	github.com/riandyrn/otelchi v0.11.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.56.0
 	go.opentelemetry.io/otel v1.32.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.32.0

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package otelchi
 
 // Version is the current release version of otelchi in use.
 func Version() string {
-	return "0.10.1"
+	return "0.11.0"
 }


### PR DESCRIPTION
- Update the returned value of `Version()` to v0.11.0
- Update dependencies example to use v0.11.0
- Update CHANGELOG.md