### PR TITLE
feat: add WithAttributesFunc option to metric config

### DIFF
--- a/metric/request_duration.go
+++ b/metric/request_duration.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	otelmetric "go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/semconv/v1.20.0/httpconv"
 )
 
 const (
@@ -40,7 +39,7 @@ func NewRequestDurationMillis(cfg BaseConfig) func(next http.Handler) http.Handl
 				r.Context(),
 				int64(duration.Milliseconds()),
 				otelmetric.WithAttributes(
-					httpconv.ServerRequest(cfg.ServerName, r)...,
+					cfg.AttributesFunc(r)...,
 				),
 			)
 		})

--- a/metric/requests_inflight.go
+++ b/metric/requests_inflight.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	otelmetric "go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/semconv/v1.20.0/httpconv"
 )
 
 const (
@@ -29,7 +28,7 @@ func NewRequestInFlight(cfg BaseConfig) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// define metric attributes
-			attrs := otelmetric.WithAttributes(httpconv.ServerRequest(cfg.ServerName, r)...)
+			attrs := otelmetric.WithAttributes(cfg.AttributesFunc(r)...)
 
 			// increase the number of requests in flight
 			counter.Add(r.Context(), 1, attrs)

--- a/metric/response_size.go
+++ b/metric/response_size.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	otelmetric "go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/semconv/v1.20.0/httpconv"
 )
 
 const (
@@ -39,7 +38,7 @@ func NewResponseSizeBytes(cfg BaseConfig) func(next http.Handler) http.Handler {
 				r.Context(),
 				int64(rrw.writtenBytes),
 				otelmetric.WithAttributes(
-					httpconv.ServerRequest(cfg.ServerName, r)...,
+					cfg.AttributesFunc(r)...,
 				),
 			)
 		})


### PR DESCRIPTION
This allows the user to control attributes set for each metric record. The previously used `httpconv.ServerRequest` remains a default.

Resolves https://github.com/riandyrn/otelchi/issues/91