### PR TITLE
Release v0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.12.2] - 2025-09-02
+
+### Fixed
+
+- Use TracerProvider from request context when available ([#92])
+- Fix high-cardinality metrics and allows user control attributes each metric record ([#95])
+
 ## [0.12.1] - 2025-02-12
 
 ### Fixed
@@ -228,6 +235,8 @@ It contains instrumentation for trace and depends on:
 - Example code for a basic usage.
 - Apache-2.0 license.
 
+[#95]: https://github.com/riandyrn/otelchi/pull/95
+[#92]: https://github.com/riandyrn/otelchi/pull/92
 [#89]: https://github.com/riandyrn/otelchi/pull/89
 [#88]: https://github.com/riandyrn/otelchi/pull/88
 [#87]: https://github.com/riandyrn/otelchi/pull/87
@@ -260,7 +269,8 @@ It contains instrumentation for trace and depends on:
 [#2]: https://github.com/riandyrn/otelchi/pull/2
 [#1]: https://github.com/riandyrn/otelchi/pull/1
 
-[Unreleased]: https://github.com/riandyrn/otelchi/compare/v0.12.1...HEAD
+[Unreleased]: https://github.com/riandyrn/otelchi/compare/v0.12.2...HEAD
+[0.12.2]: https://github.com/riandyrn/otelchi/releases/tag/v0.12.2
 [0.12.1]: https://github.com/riandyrn/otelchi/releases/tag/v0.12.1
 [0.12.0]: https://github.com/riandyrn/otelchi/releases/tag/v0.12.0
 [0.11.0]: https://github.com/riandyrn/otelchi/releases/tag/v0.11.0

--- a/examples/basic/go.mod
+++ b/examples/basic/go.mod
@@ -6,7 +6,7 @@ replace github.com/riandyrn/otelchi => ../../
 
 require (
 	github.com/go-chi/chi/v5 v5.1.0
-	github.com/riandyrn/otelchi v0.12.1
+	github.com/riandyrn/otelchi v0.12.2
 	go.opentelemetry.io/otel v1.34.0
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.34.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.34.0

--- a/examples/multi-services/go.mod
+++ b/examples/multi-services/go.mod
@@ -6,7 +6,7 @@ replace github.com/riandyrn/otelchi => ../../
 
 require (
 	github.com/go-chi/chi/v5 v5.1.0
-	github.com/riandyrn/otelchi v0.12.1
+	github.com/riandyrn/otelchi v0.12.2
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.56.0
 	go.opentelemetry.io/otel v1.34.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.34.0

--- a/version/version.go
+++ b/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current release version of otelchi in use.
 func Version() string {
-	return "0.12.1"
+	return "0.12.2"
 }


### PR DESCRIPTION
- Include fixing high-cardinality metric attribute
- include to use TracerProvider from request context when available
- Update the returned value of version.Version() to v0.12.2
- Update dependencies example to use v0.12.2
- Update CHANGELOG.md