### PR TITLE
Fix response size sum in metrics

### DIFF
--- a/metric/config.go
+++ b/metric/config.go
@@ -116,14 +116,14 @@ func getRRW(writer http.ResponseWriter) *recordingResponseWriter {
 	rrw.writer = httpsnoop.Wrap(writer, httpsnoop.Hooks{
 		Write: func(next httpsnoop.WriteFunc) httpsnoop.WriteFunc {
 			return func(b []byte) (int, error) {
-				if !rrw.written {
+				n, err := next(b)
+				rrw.writtenBytes += int64(n)
+				if !rrw.written && n > 0 {
 					rrw.written = true
-					rrw.writtenBytes += int64(len(b))
 				}
-				return next(b)
+				return n, err
 			}
-		},
-		WriteHeader: func(next httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
+		}, WriteHeader: func(next httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
 			return func(statusCode int) {
 				if !rrw.written {
 					rrw.written = true

--- a/metric/response_size_test.go
+++ b/metric/response_size_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/riandyrn/otelchi/metric"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
@@ -52,4 +53,98 @@ func TestResponseSizeBytes(t *testing.T) {
 	dp := hist.DataPoints[0]
 	assert.Equal(t, int64(len(responseMsg)), dp.Sum)
 	assert.Equal(t, uint64(1), dp.Count)
+}
+
+func TestResponseSizeBytesAccumulationIssue(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(reader),
+	)
+
+	cfg := metric.NewBaseConfig(
+		"test-server",
+		metric.WithMeterProvider(meterProvider),
+		metric.WithAttributesFunc(func(r *http.Request) []attribute.KeyValue {
+			return []attribute.KeyValue{}
+		}),
+	)
+
+	// handler writes response in 3 separate Write calls
+	// total expected bytes: 5 + 6 + 4 = 15
+	chunks := []string{"hello", " world", " bye"}
+	totalExpected := int64(0)
+	for _, c := range chunks {
+		totalExpected += int64(len(c))
+	}
+
+	handler := metric.NewResponseSizeBytes(cfg)(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			for _, chunk := range chunks {
+				n, err := w.Write([]byte(chunk))
+				if err != nil {
+					t.Errorf("unexpected write error: %v", err)
+					return
+				}
+				if n != len(chunk) {
+					t.Errorf("expected to write %d bytes, wrote %d", len(chunk), n)
+					return
+				}
+			}
+		}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	// collect metrics
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(req.Context(), &rm); err != nil {
+		t.Fatalf("failed to collect metrics: %v", err)
+	}
+
+	histogram := findHistogram(t, rm, "response_size_bytes")
+	if histogram == nil {
+		t.Fatal("response_size_bytes histogram not found")
+	}
+
+	if len(histogram.DataPoints) != 1 {
+		t.Fatalf("expected 1 data point, got %d", len(histogram.DataPoints))
+	}
+
+	got := histogram.DataPoints[0].Sum
+	if got != totalExpected {
+		t.Errorf(
+			"regression: response size bytes accumulation is broken.\n"+
+				"wrote %d bytes across %d Write calls, but metric recorded %d bytes.\n"+
+				"this indicates only the first Write call was counted",
+			totalExpected,
+			len(chunks),
+			got,
+		)
+	}
+}
+
+// findHistogram is a helper that looks up a specific Int64Histogram
+// by name from collected ResourceMetrics.
+func findHistogram(
+	t *testing.T,
+	rm metricdata.ResourceMetrics,
+	name string,
+) *metricdata.Histogram[int64] {
+	t.Helper()
+
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			histogram, ok := m.Data.(metricdata.Histogram[int64])
+			if !ok {
+				t.Fatalf("metric %q is not a Histogram[int64]", name)
+			}
+			return &histogram
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Fix response size metric aggregation

The `http_server_response_size_bytes_sum` metric was incorrectly reporting zero because `writtenBytes` was only incremented on the first `Write` call, when `!rrw.written`. This ignored all subsequent writes, leading to inaccurate or zero size reporting, especially for responses written in multiple chunks.

Updated the `Write` hook to always increment `writtenBytes` by the actual number of written bytes (`n`), not `len(b)`, and to track the first non-zero write separately. This ensures accurate response size measurement regardless of write pattern.

Changes:
- Fix incorrect `writtenBytes` accumulation
- Use `n` (actual written bytes) instead of `len(b)`
- Preserve `written` flag logic for `WriteHeader` tracking
