### PR TITLE
Adding http.response.status_code to duration metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Add `http.response.status_code` attribute to the `http.server.request.duration` metric so HTTP error-rate (4xx/5xx) breakdowns can be derived from metrics.
+
 ## [0.12.3] - 2026-05-03
 
 ### Added

--- a/metric/server_request_duration.go
+++ b/metric/server_request_duration.go
@@ -3,9 +3,10 @@ package metric
 import (
 	"fmt"
 	"net/http"
-	"time"
 
+	"github.com/felixge/httpsnoop"
 	otelmetric "go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
 const (
@@ -35,17 +36,17 @@ func NewServerRequestDuration(cfg BaseConfig) func(next http.Handler) http.Handl
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			startTime := time.Now()
+			// CaptureMetrics runs next and reports the final status code (defaulting
+			// to 200 when the handler never calls WriteHeader) and the duration.
+			metrics := httpsnoop.CaptureMetrics(next, w, r)
 
-			next.ServeHTTP(w, r)
+			attrs := cfg.AttributesFunc(r)
+			attrs = append(attrs, semconv.HTTPResponseStatusCode(metrics.Code))
 
-			duration := time.Since(startTime)
 			histogram.Record(
 				r.Context(),
-				float64(duration)/float64(time.Second),
-				otelmetric.WithAttributes(
-					cfg.AttributesFunc(r)...,
-				),
+				metrics.Duration.Seconds(),
+				otelmetric.WithAttributes(attrs...),
 			)
 		})
 	}

--- a/metric/server_request_duration_test.go
+++ b/metric/server_request_duration_test.go
@@ -46,3 +46,49 @@ func TestServerRequestDuration(t *testing.T) {
 	assert.Equal(t, uint64(1), dp.Count)
 	assertHasAttribute(t, dp.Attributes, attribute.String("test.attr", "value"))
 }
+
+func TestServerRequestDuration_RecordsStatusCode(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	baseCfg := metric.NewBaseConfig("test-server", metric.WithMeterProvider(provider))
+
+	router := chi.NewRouter()
+	router.Use(metric.NewServerRequestDuration(baseCfg))
+	router.Get("/created", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	router.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/created", nil))
+
+	m := findMetric(t, collectMetrics(t, reader), "http.server.request.duration")
+	histogram, ok := m.Data.(metricdata.Histogram[float64])
+	require.True(t, ok)
+	require.Len(t, histogram.DataPoints, 1)
+
+	v, ok := histogram.DataPoints[0].Attributes.Value(attribute.Key("http.response.status_code"))
+	require.True(t, ok, "http.response.status_code attribute missing")
+	assert.Equal(t, int64(201), v.AsInt64())
+}
+
+func TestServerRequestDuration_DefaultsStatusCodeTo200(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	baseCfg := metric.NewBaseConfig("test-server", metric.WithMeterProvider(provider))
+
+	router := chi.NewRouter()
+	router.Use(metric.NewServerRequestDuration(baseCfg))
+	router.Get("/ok", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok")) // implicit 200, no WriteHeader
+	})
+
+	router.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/ok", nil))
+
+	m := findMetric(t, collectMetrics(t, reader), "http.server.request.duration")
+	histogram, ok := m.Data.(metricdata.Histogram[float64])
+	require.True(t, ok)
+	require.Len(t, histogram.DataPoints, 1)
+
+	v, ok := histogram.DataPoints[0].Attributes.Value(attribute.Key("http.response.status_code"))
+	require.True(t, ok)
+	assert.Equal(t, int64(200), v.AsInt64())
+}


### PR DESCRIPTION

The metric currently records duration with method/scheme/route but no status code, so consumers can't derive HTTP error-rate (4xx/5xx) breakdowns from metrics — the most common RED-method panel. This matches otelhttp, which already includes the status code on the same metric.

`NewServerRequestDuration` now uses `httpsnoop.CaptureMetrics` (already a dependency) to obtain the final status code (defaulting to 200 when the handler never calls WriteHeader) and the duration, and appends `semconv.HTTPResponseStatusCode(code)` to the recorded attributes. The request-only `AttributesFunc` hook is unchanged, so this is non-breaking.

**NOTE**: the current codebase doesn't fully follow the semconv as defined by open telemetry. But there seems to be the incentive to go towards the newer library versions and conventions (#103 ). Thus this change already leans towards the semconv `http.response.status_code`